### PR TITLE
refactor(php): use self::markTestIncomplete instead of instance calls

### DIFF
--- a/modules/openapi-generator/src/main/resources/php-nextgen/api_test.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/api_test.mustache
@@ -70,7 +70,7 @@ use PHPUnit\Framework\TestCase;
     public function test{{vendorExtensions.x-test-operation-id}}()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
     {{/operation}}
 }

--- a/modules/openapi-generator/src/main/resources/php-nextgen/model_test.mustache
+++ b/modules/openapi-generator/src/main/resources/php-nextgen/model_test.mustache
@@ -67,7 +67,7 @@ class {{classname}}Test extends TestCase
     public function test{{classname}}()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 {{#vars}}
 
@@ -77,7 +77,7 @@ class {{classname}}Test extends TestCase
     public function testProperty{{nameInCamelCase}}()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 {{/vars}}
 }

--- a/modules/openapi-generator/src/main/resources/php-slim4-server/api_test.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim4-server/api_test.mustache
@@ -62,7 +62,7 @@ class {{userClassname}}Test extends TestCase
      */
     public function test{{operationIdCamelCase}}()
     {
-        $this->markTestIncomplete(
+        self::markTestIncomplete(
             'Test of "{{operationId}}" method has not been implemented yet.'
         );
     }

--- a/modules/openapi-generator/src/main/resources/php-slim4-server/model_test.mustache
+++ b/modules/openapi-generator/src/main/resources/php-slim4-server/model_test.mustache
@@ -65,7 +65,7 @@ class {{classname}}Test extends TestCase
             class_exists($namespacedClassname),
             sprintf('Assertion failed that "%s" class exists', $namespacedClassname)
         );
-        $this->markTestIncomplete(
+        self::markTestIncomplete(
             'Test of "{{classname}}" model has not been implemented yet.'
         );
     }
@@ -76,7 +76,7 @@ class {{classname}}Test extends TestCase
      */
     public function testProperty{{nameInCamelCase}}()
     {
-        $this->markTestIncomplete(
+        self::markTestIncomplete(
             'Test of "{{name}}" property in "{{classname}}" model has not been implemented yet.'
         );
     }

--- a/modules/openapi-generator/src/main/resources/php/api_test.mustache
+++ b/modules/openapi-generator/src/main/resources/php/api_test.mustache
@@ -72,7 +72,7 @@ use PHPUnit\Framework\TestCase;
     public function test{{vendorExtensions.x-test-operation-id}}()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
     {{/operation}}
 }

--- a/modules/openapi-generator/src/main/resources/php/model_test.mustache
+++ b/modules/openapi-generator/src/main/resources/php/model_test.mustache
@@ -69,7 +69,7 @@ class {{classname}}Test extends TestCase
     public function test{{classname}}()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 {{#vars}}
 
@@ -79,7 +79,7 @@ class {{classname}}Test extends TestCase
     public function testProperty{{nameInCamelCase}}()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 {{/vars}}
 }

--- a/samples/client/echo_api/php-nextgen/tests/Api/AuthApiTest.php
+++ b/samples/client/echo_api/php-nextgen/tests/Api/AuthApiTest.php
@@ -81,6 +81,6 @@ class AuthApiTest extends TestCase
     public function testTestAuthHttpBasic()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/echo_api/php-nextgen/tests/Api/BodyApiTest.php
+++ b/samples/client/echo_api/php-nextgen/tests/Api/BodyApiTest.php
@@ -81,7 +81,7 @@ class BodyApiTest extends TestCase
     public function testTestBinaryGif()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -93,7 +93,7 @@ class BodyApiTest extends TestCase
     public function testTestBodyApplicationOctetstreamBinary()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -105,7 +105,7 @@ class BodyApiTest extends TestCase
     public function testTestBodyMultipartFormdataArrayOfBinary()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -117,7 +117,7 @@ class BodyApiTest extends TestCase
     public function testTestEchoBodyFreeFormObjectResponseString()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -129,7 +129,7 @@ class BodyApiTest extends TestCase
     public function testTestEchoBodyPet()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -141,7 +141,7 @@ class BodyApiTest extends TestCase
     public function testTestEchoBodyPetResponseString()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -153,6 +153,6 @@ class BodyApiTest extends TestCase
     public function testTestEchoBodyTagResponseString()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/echo_api/php-nextgen/tests/Api/FormApiTest.php
+++ b/samples/client/echo_api/php-nextgen/tests/Api/FormApiTest.php
@@ -81,7 +81,7 @@ class FormApiTest extends TestCase
     public function testTestFormIntegerBooleanString()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -93,6 +93,6 @@ class FormApiTest extends TestCase
     public function testTestFormOneof()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/echo_api/php-nextgen/tests/Api/HeaderApiTest.php
+++ b/samples/client/echo_api/php-nextgen/tests/Api/HeaderApiTest.php
@@ -81,6 +81,6 @@ class HeaderApiTest extends TestCase
     public function testTestHeaderIntegerBooleanString()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/echo_api/php-nextgen/tests/Api/PathApiTest.php
+++ b/samples/client/echo_api/php-nextgen/tests/Api/PathApiTest.php
@@ -81,6 +81,6 @@ class PathApiTest extends TestCase
     public function testTestsPathStringPathStringIntegerPathInteger()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/echo_api/php-nextgen/tests/Api/QueryApiTest.php
+++ b/samples/client/echo_api/php-nextgen/tests/Api/QueryApiTest.php
@@ -81,7 +81,7 @@ class QueryApiTest extends TestCase
     public function testTestEnumRefString()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -93,7 +93,7 @@ class QueryApiTest extends TestCase
     public function testTestQueryDatetimeDateString()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -105,7 +105,7 @@ class QueryApiTest extends TestCase
     public function testTestQueryIntegerBooleanString()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -117,7 +117,7 @@ class QueryApiTest extends TestCase
     public function testTestQueryStyleDeepObjectExplodeTrueObject()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -129,7 +129,7 @@ class QueryApiTest extends TestCase
     public function testTestQueryStyleDeepObjectExplodeTrueObjectAllOf()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -141,7 +141,7 @@ class QueryApiTest extends TestCase
     public function testTestQueryStyleFormExplodeTrueArrayString()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -153,7 +153,7 @@ class QueryApiTest extends TestCase
     public function testTestQueryStyleFormExplodeTrueObject()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -165,6 +165,6 @@ class QueryApiTest extends TestCase
     public function testTestQueryStyleFormExplodeTrueObjectAllOf()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/echo_api/php-nextgen/tests/Model/BirdTest.php
+++ b/samples/client/echo_api/php-nextgen/tests/Model/BirdTest.php
@@ -77,7 +77,7 @@ class BirdTest extends TestCase
     public function testBird()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -86,7 +86,7 @@ class BirdTest extends TestCase
     public function testPropertySize()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -95,6 +95,6 @@ class BirdTest extends TestCase
     public function testPropertyColor()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/echo_api/php-nextgen/tests/Model/CategoryTest.php
+++ b/samples/client/echo_api/php-nextgen/tests/Model/CategoryTest.php
@@ -77,7 +77,7 @@ class CategoryTest extends TestCase
     public function testCategory()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -86,7 +86,7 @@ class CategoryTest extends TestCase
     public function testPropertyId()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -95,6 +95,6 @@ class CategoryTest extends TestCase
     public function testPropertyName()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/echo_api/php-nextgen/tests/Model/DataQueryTest.php
+++ b/samples/client/echo_api/php-nextgen/tests/Model/DataQueryTest.php
@@ -77,7 +77,7 @@ class DataQueryTest extends TestCase
     public function testDataQuery()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -86,7 +86,7 @@ class DataQueryTest extends TestCase
     public function testPropertySuffix()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -95,7 +95,7 @@ class DataQueryTest extends TestCase
     public function testPropertyText()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -104,6 +104,6 @@ class DataQueryTest extends TestCase
     public function testPropertyDate()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/echo_api/php-nextgen/tests/Model/DefaultValueTest.php
+++ b/samples/client/echo_api/php-nextgen/tests/Model/DefaultValueTest.php
@@ -77,7 +77,7 @@ class DefaultValueTest extends TestCase
     public function testDefaultValue()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -86,7 +86,7 @@ class DefaultValueTest extends TestCase
     public function testPropertyArrayStringEnumRefDefault()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -95,7 +95,7 @@ class DefaultValueTest extends TestCase
     public function testPropertyArrayStringEnumDefault()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -104,7 +104,7 @@ class DefaultValueTest extends TestCase
     public function testPropertyArrayStringDefault()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -113,7 +113,7 @@ class DefaultValueTest extends TestCase
     public function testPropertyArrayIntegerDefault()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -122,7 +122,7 @@ class DefaultValueTest extends TestCase
     public function testPropertyArrayString()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -131,7 +131,7 @@ class DefaultValueTest extends TestCase
     public function testPropertyArrayStringNullable()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -140,7 +140,7 @@ class DefaultValueTest extends TestCase
     public function testPropertyArrayStringExtensionNullable()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -149,6 +149,6 @@ class DefaultValueTest extends TestCase
     public function testPropertyStringNullable()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/echo_api/php-nextgen/tests/Model/NumberPropertiesOnlyTest.php
+++ b/samples/client/echo_api/php-nextgen/tests/Model/NumberPropertiesOnlyTest.php
@@ -77,7 +77,7 @@ class NumberPropertiesOnlyTest extends TestCase
     public function testNumberPropertiesOnly()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -86,7 +86,7 @@ class NumberPropertiesOnlyTest extends TestCase
     public function testPropertyNumber()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -95,7 +95,7 @@ class NumberPropertiesOnlyTest extends TestCase
     public function testPropertyFloat()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -104,6 +104,6 @@ class NumberPropertiesOnlyTest extends TestCase
     public function testPropertyDouble()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/echo_api/php-nextgen/tests/Model/PetTest.php
+++ b/samples/client/echo_api/php-nextgen/tests/Model/PetTest.php
@@ -77,7 +77,7 @@ class PetTest extends TestCase
     public function testPet()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -86,7 +86,7 @@ class PetTest extends TestCase
     public function testPropertyId()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -95,7 +95,7 @@ class PetTest extends TestCase
     public function testPropertyName()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -104,7 +104,7 @@ class PetTest extends TestCase
     public function testPropertyCategory()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -113,7 +113,7 @@ class PetTest extends TestCase
     public function testPropertyPhotoUrls()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -122,7 +122,7 @@ class PetTest extends TestCase
     public function testPropertyTags()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -131,6 +131,6 @@ class PetTest extends TestCase
     public function testPropertyStatus()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/echo_api/php-nextgen/tests/Model/QueryTest.php
+++ b/samples/client/echo_api/php-nextgen/tests/Model/QueryTest.php
@@ -77,7 +77,7 @@ class QueryTest extends TestCase
     public function testQuery()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -86,7 +86,7 @@ class QueryTest extends TestCase
     public function testPropertyId()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -95,6 +95,6 @@ class QueryTest extends TestCase
     public function testPropertyOutcomes()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/echo_api/php-nextgen/tests/Model/StringEnumRefTest.php
+++ b/samples/client/echo_api/php-nextgen/tests/Model/StringEnumRefTest.php
@@ -77,6 +77,6 @@ class StringEnumRefTest extends TestCase
     public function testStringEnumRef()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/echo_api/php-nextgen/tests/Model/TagTest.php
+++ b/samples/client/echo_api/php-nextgen/tests/Model/TagTest.php
@@ -77,7 +77,7 @@ class TagTest extends TestCase
     public function testTag()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -86,7 +86,7 @@ class TagTest extends TestCase
     public function testPropertyId()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -95,6 +95,6 @@ class TagTest extends TestCase
     public function testPropertyName()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/echo_api/php-nextgen/tests/Model/TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameterTest.php
+++ b/samples/client/echo_api/php-nextgen/tests/Model/TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameterTest.php
@@ -77,7 +77,7 @@ class TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameterTest ext
     public function testTestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameter()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -86,7 +86,7 @@ class TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameterTest ext
     public function testPropertySize()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -95,7 +95,7 @@ class TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameterTest ext
     public function testPropertyColor()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -104,7 +104,7 @@ class TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameterTest ext
     public function testPropertyId()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -113,6 +113,6 @@ class TestQueryStyleDeepObjectExplodeTrueObjectAllOfQueryObjectParameterTest ext
     public function testPropertyName()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/echo_api/php-nextgen/tests/Model/TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameterTest.php
+++ b/samples/client/echo_api/php-nextgen/tests/Model/TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameterTest.php
@@ -77,7 +77,7 @@ class TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameterTest extends T
     public function testTestQueryStyleFormExplodeTrueArrayStringQueryObjectParameter()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -86,6 +86,6 @@ class TestQueryStyleFormExplodeTrueArrayStringQueryObjectParameterTest extends T
     public function testPropertyValues()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Api/AnotherFakeApiTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Api/AnotherFakeApiTest.php
@@ -80,6 +80,6 @@ class AnotherFakeApiTest extends TestCase
     public function testCall123TestSpecialTags()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Api/DefaultApiTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Api/DefaultApiTest.php
@@ -80,6 +80,6 @@ class DefaultApiTest extends TestCase
     public function testFooGet()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Api/FakeApiTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Api/FakeApiTest.php
@@ -80,7 +80,7 @@ class FakeApiTest extends TestCase
     public function testFakeHealthGet()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -92,7 +92,7 @@ class FakeApiTest extends TestCase
     public function testFakeHttpSignatureTest()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -104,7 +104,7 @@ class FakeApiTest extends TestCase
     public function testFakeOuterBooleanSerialize()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -116,7 +116,7 @@ class FakeApiTest extends TestCase
     public function testFakeOuterCompositeSerialize()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -128,7 +128,7 @@ class FakeApiTest extends TestCase
     public function testFakeOuterNumberSerialize()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -140,7 +140,7 @@ class FakeApiTest extends TestCase
     public function testFakeOuterStringSerialize()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -152,7 +152,7 @@ class FakeApiTest extends TestCase
     public function testFakePropertyEnumIntegerSerialize()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -164,7 +164,7 @@ class FakeApiTest extends TestCase
     public function testTestBodyWithBinary()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -176,7 +176,7 @@ class FakeApiTest extends TestCase
     public function testTestBodyWithFileSchema()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -188,7 +188,7 @@ class FakeApiTest extends TestCase
     public function testTestBodyWithQueryParams()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -200,7 +200,7 @@ class FakeApiTest extends TestCase
     public function testTestClientModel()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -212,7 +212,7 @@ class FakeApiTest extends TestCase
     public function testTestEndpointParameters()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -224,7 +224,7 @@ class FakeApiTest extends TestCase
     public function testTestEnumParameters()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -236,7 +236,7 @@ class FakeApiTest extends TestCase
     public function testTestGroupParameters()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -248,7 +248,7 @@ class FakeApiTest extends TestCase
     public function testTestInlineAdditionalProperties()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -260,7 +260,7 @@ class FakeApiTest extends TestCase
     public function testTestJsonFormData()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -272,6 +272,6 @@ class FakeApiTest extends TestCase
     public function testTestQueryParameterCollectionFormat()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Api/FakeClassnameTags123ApiTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Api/FakeClassnameTags123ApiTest.php
@@ -80,6 +80,6 @@ class FakeClassnameTags123ApiTest extends TestCase
     public function testTestClassname()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Api/PetApiTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Api/PetApiTest.php
@@ -80,7 +80,7 @@ class PetApiTest extends TestCase
     public function testAddPet()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -92,7 +92,7 @@ class PetApiTest extends TestCase
     public function testDeletePet()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -104,7 +104,7 @@ class PetApiTest extends TestCase
     public function testFindPetsByStatus()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -116,7 +116,7 @@ class PetApiTest extends TestCase
     public function testFindPetsByTags()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -128,7 +128,7 @@ class PetApiTest extends TestCase
     public function testGetPetById()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -140,7 +140,7 @@ class PetApiTest extends TestCase
     public function testUpdatePet()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -152,7 +152,7 @@ class PetApiTest extends TestCase
     public function testUpdatePetWithForm()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -164,7 +164,7 @@ class PetApiTest extends TestCase
     public function testUploadFile()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -176,6 +176,6 @@ class PetApiTest extends TestCase
     public function testUploadFileWithRequiredFile()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Api/StoreApiTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Api/StoreApiTest.php
@@ -80,7 +80,7 @@ class StoreApiTest extends TestCase
     public function testDeleteOrder()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -92,7 +92,7 @@ class StoreApiTest extends TestCase
     public function testGetInventory()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -104,7 +104,7 @@ class StoreApiTest extends TestCase
     public function testGetOrderById()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -116,6 +116,6 @@ class StoreApiTest extends TestCase
     public function testPlaceOrder()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Api/UserApiTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Api/UserApiTest.php
@@ -80,7 +80,7 @@ class UserApiTest extends TestCase
     public function testCreateUser()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -92,7 +92,7 @@ class UserApiTest extends TestCase
     public function testCreateUsersWithArrayInput()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -104,7 +104,7 @@ class UserApiTest extends TestCase
     public function testCreateUsersWithListInput()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -116,7 +116,7 @@ class UserApiTest extends TestCase
     public function testDeleteUser()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -128,7 +128,7 @@ class UserApiTest extends TestCase
     public function testGetUserByName()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -140,7 +140,7 @@ class UserApiTest extends TestCase
     public function testLoginUser()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -152,7 +152,7 @@ class UserApiTest extends TestCase
     public function testLogoutUser()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -164,6 +164,6 @@ class UserApiTest extends TestCase
     public function testUpdateUser()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/AdditionalPropertiesClassTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/AdditionalPropertiesClassTest.php
@@ -76,7 +76,7 @@ class AdditionalPropertiesClassTest extends TestCase
     public function testAdditionalPropertiesClass()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class AdditionalPropertiesClassTest extends TestCase
     public function testPropertyMapProperty()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,6 +94,6 @@ class AdditionalPropertiesClassTest extends TestCase
     public function testPropertyMapOfMapProperty()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/AllOfWithSingleRefTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/AllOfWithSingleRefTest.php
@@ -76,7 +76,7 @@ class AllOfWithSingleRefTest extends TestCase
     public function testAllOfWithSingleRef()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class AllOfWithSingleRefTest extends TestCase
     public function testPropertyUsername()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,6 +94,6 @@ class AllOfWithSingleRefTest extends TestCase
     public function testPropertySingleRefType()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/AnimalTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/AnimalTest.php
@@ -76,7 +76,7 @@ class AnimalTest extends TestCase
     public function testAnimal()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class AnimalTest extends TestCase
     public function testPropertyClassName()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,6 +94,6 @@ class AnimalTest extends TestCase
     public function testPropertyColor()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/ApiResponseTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/ApiResponseTest.php
@@ -76,7 +76,7 @@ class ApiResponseTest extends TestCase
     public function testApiResponse()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class ApiResponseTest extends TestCase
     public function testPropertyCode()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,7 +94,7 @@ class ApiResponseTest extends TestCase
     public function testPropertyType()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -103,6 +103,6 @@ class ApiResponseTest extends TestCase
     public function testPropertyMessage()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/ArrayOfArrayOfNumberOnlyTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/ArrayOfArrayOfNumberOnlyTest.php
@@ -76,7 +76,7 @@ class ArrayOfArrayOfNumberOnlyTest extends TestCase
     public function testArrayOfArrayOfNumberOnly()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,6 +85,6 @@ class ArrayOfArrayOfNumberOnlyTest extends TestCase
     public function testPropertyArrayArrayNumber()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/ArrayOfNumberOnlyTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/ArrayOfNumberOnlyTest.php
@@ -76,7 +76,7 @@ class ArrayOfNumberOnlyTest extends TestCase
     public function testArrayOfNumberOnly()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,6 +85,6 @@ class ArrayOfNumberOnlyTest extends TestCase
     public function testPropertyArrayNumber()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/ArrayTestTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/ArrayTestTest.php
@@ -76,7 +76,7 @@ class ArrayTestTest extends TestCase
     public function testArrayTest()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class ArrayTestTest extends TestCase
     public function testPropertyArrayOfString()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,7 +94,7 @@ class ArrayTestTest extends TestCase
     public function testPropertyArrayArrayOfInteger()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -103,6 +103,6 @@ class ArrayTestTest extends TestCase
     public function testPropertyArrayArrayOfModel()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/CapitalizationTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/CapitalizationTest.php
@@ -76,7 +76,7 @@ class CapitalizationTest extends TestCase
     public function testCapitalization()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class CapitalizationTest extends TestCase
     public function testPropertySmallCamel()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,7 +94,7 @@ class CapitalizationTest extends TestCase
     public function testPropertyCapitalCamel()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -103,7 +103,7 @@ class CapitalizationTest extends TestCase
     public function testPropertySmallSnake()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -112,7 +112,7 @@ class CapitalizationTest extends TestCase
     public function testPropertyCapitalSnake()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -121,7 +121,7 @@ class CapitalizationTest extends TestCase
     public function testPropertyScaEthFlowPoints()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -130,6 +130,6 @@ class CapitalizationTest extends TestCase
     public function testPropertyAttName()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/CatAllOfTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/CatAllOfTest.php
@@ -76,7 +76,7 @@ class CatAllOfTest extends TestCase
     public function testCatAllOf()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,6 +85,6 @@ class CatAllOfTest extends TestCase
     public function testPropertyDeclawed()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/CatTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/CatTest.php
@@ -76,7 +76,7 @@ class CatTest extends TestCase
     public function testCat()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,6 +85,6 @@ class CatTest extends TestCase
     public function testPropertyDeclawed()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/CategoryTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/CategoryTest.php
@@ -76,7 +76,7 @@ class CategoryTest extends TestCase
     public function testCategory()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class CategoryTest extends TestCase
     public function testPropertyId()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,6 +94,6 @@ class CategoryTest extends TestCase
     public function testPropertyName()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/ChildWithNullableTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/ChildWithNullableTest.php
@@ -76,7 +76,7 @@ class ChildWithNullableTest extends TestCase
     public function testChildWithNullable()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,6 +85,6 @@ class ChildWithNullableTest extends TestCase
     public function testPropertyOtherProperty()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/ClassModelTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/ClassModelTest.php
@@ -76,7 +76,7 @@ class ClassModelTest extends TestCase
     public function testClassModel()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,6 +85,6 @@ class ClassModelTest extends TestCase
     public function testPropertyClass()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/ClientTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/ClientTest.php
@@ -76,7 +76,7 @@ class ClientTest extends TestCase
     public function testClient()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,6 +85,6 @@ class ClientTest extends TestCase
     public function testPropertyClient()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/DeprecatedObjectTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/DeprecatedObjectTest.php
@@ -76,7 +76,7 @@ class DeprecatedObjectTest extends TestCase
     public function testDeprecatedObject()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,6 +85,6 @@ class DeprecatedObjectTest extends TestCase
     public function testPropertyName()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/DogAllOfTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/DogAllOfTest.php
@@ -76,7 +76,7 @@ class DogAllOfTest extends TestCase
     public function testDogAllOf()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,6 +85,6 @@ class DogAllOfTest extends TestCase
     public function testPropertyBreed()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/DogTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/DogTest.php
@@ -76,7 +76,7 @@ class DogTest extends TestCase
     public function testDog()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,6 +85,6 @@ class DogTest extends TestCase
     public function testPropertyBreed()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/EnumArraysTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/EnumArraysTest.php
@@ -76,7 +76,7 @@ class EnumArraysTest extends TestCase
     public function testEnumArrays()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class EnumArraysTest extends TestCase
     public function testPropertyJustSymbol()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,6 +94,6 @@ class EnumArraysTest extends TestCase
     public function testPropertyArrayEnum()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/EnumClassTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/EnumClassTest.php
@@ -76,6 +76,6 @@ class EnumClassTest extends TestCase
     public function testEnumClass()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/EnumTestTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/EnumTestTest.php
@@ -76,7 +76,7 @@ class EnumTestTest extends TestCase
     public function testEnumTest()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class EnumTestTest extends TestCase
     public function testPropertyEnumString()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,7 +94,7 @@ class EnumTestTest extends TestCase
     public function testPropertyEnumStringRequired()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -103,7 +103,7 @@ class EnumTestTest extends TestCase
     public function testPropertyEnumInteger()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -112,7 +112,7 @@ class EnumTestTest extends TestCase
     public function testPropertyEnumNumber()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -121,7 +121,7 @@ class EnumTestTest extends TestCase
     public function testPropertyOuterEnum()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -130,7 +130,7 @@ class EnumTestTest extends TestCase
     public function testPropertyOuterEnumInteger()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -139,7 +139,7 @@ class EnumTestTest extends TestCase
     public function testPropertyOuterEnumDefaultValue()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -148,6 +148,6 @@ class EnumTestTest extends TestCase
     public function testPropertyOuterEnumIntegerDefaultValue()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/FakeBigDecimalMap200ResponseTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/FakeBigDecimalMap200ResponseTest.php
@@ -76,7 +76,7 @@ class FakeBigDecimalMap200ResponseTest extends TestCase
     public function testFakeBigDecimalMap200Response()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class FakeBigDecimalMap200ResponseTest extends TestCase
     public function testPropertySomeId()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,6 +94,6 @@ class FakeBigDecimalMap200ResponseTest extends TestCase
     public function testPropertySomeMap()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/FileSchemaTestClassTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/FileSchemaTestClassTest.php
@@ -76,7 +76,7 @@ class FileSchemaTestClassTest extends TestCase
     public function testFileSchemaTestClass()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class FileSchemaTestClassTest extends TestCase
     public function testPropertyFile()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,6 +94,6 @@ class FileSchemaTestClassTest extends TestCase
     public function testPropertyFiles()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/FileTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/FileTest.php
@@ -76,7 +76,7 @@ class FileTest extends TestCase
     public function testFile()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,6 +85,6 @@ class FileTest extends TestCase
     public function testPropertySourceUri()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/FooGetDefaultResponseTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/FooGetDefaultResponseTest.php
@@ -76,7 +76,7 @@ class FooGetDefaultResponseTest extends TestCase
     public function testFooGetDefaultResponse()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,6 +85,6 @@ class FooGetDefaultResponseTest extends TestCase
     public function testPropertyString()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/FooTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/FooTest.php
@@ -76,7 +76,7 @@ class FooTest extends TestCase
     public function testFoo()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,6 +85,6 @@ class FooTest extends TestCase
     public function testPropertyBar()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/FormatTestTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/FormatTestTest.php
@@ -76,7 +76,7 @@ class FormatTestTest extends TestCase
     public function testFormatTest()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class FormatTestTest extends TestCase
     public function testPropertyInteger()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,7 +94,7 @@ class FormatTestTest extends TestCase
     public function testPropertyInt32()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -103,7 +103,7 @@ class FormatTestTest extends TestCase
     public function testPropertyInt64()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -112,7 +112,7 @@ class FormatTestTest extends TestCase
     public function testPropertyNumber()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -121,7 +121,7 @@ class FormatTestTest extends TestCase
     public function testPropertyFloat()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -130,7 +130,7 @@ class FormatTestTest extends TestCase
     public function testPropertyDouble()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -139,7 +139,7 @@ class FormatTestTest extends TestCase
     public function testPropertyDecimal()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -148,7 +148,7 @@ class FormatTestTest extends TestCase
     public function testPropertyString()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -157,7 +157,7 @@ class FormatTestTest extends TestCase
     public function testPropertyByte()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -166,7 +166,7 @@ class FormatTestTest extends TestCase
     public function testPropertyBinary()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -175,7 +175,7 @@ class FormatTestTest extends TestCase
     public function testPropertyDate()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -184,7 +184,7 @@ class FormatTestTest extends TestCase
     public function testPropertyDateTime()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -193,7 +193,7 @@ class FormatTestTest extends TestCase
     public function testPropertyUuid()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -202,7 +202,7 @@ class FormatTestTest extends TestCase
     public function testPropertyPassword()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -211,7 +211,7 @@ class FormatTestTest extends TestCase
     public function testPropertyPatternWithDigits()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -220,6 +220,6 @@ class FormatTestTest extends TestCase
     public function testPropertyPatternWithDigitsAndDelimiter()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/HasOnlyReadOnlyTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/HasOnlyReadOnlyTest.php
@@ -76,7 +76,7 @@ class HasOnlyReadOnlyTest extends TestCase
     public function testHasOnlyReadOnly()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class HasOnlyReadOnlyTest extends TestCase
     public function testPropertyBar()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,6 +94,6 @@ class HasOnlyReadOnlyTest extends TestCase
     public function testPropertyFoo()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/HealthCheckResultTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/HealthCheckResultTest.php
@@ -76,7 +76,7 @@ class HealthCheckResultTest extends TestCase
     public function testHealthCheckResult()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,6 +85,6 @@ class HealthCheckResultTest extends TestCase
     public function testPropertyNullableMessage()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/MapTestTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/MapTestTest.php
@@ -76,7 +76,7 @@ class MapTestTest extends TestCase
     public function testMapTest()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class MapTestTest extends TestCase
     public function testPropertyMapMapOfString()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,7 +94,7 @@ class MapTestTest extends TestCase
     public function testPropertyMapOfEnumString()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -103,7 +103,7 @@ class MapTestTest extends TestCase
     public function testPropertyDirectMap()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -112,6 +112,6 @@ class MapTestTest extends TestCase
     public function testPropertyIndirectMap()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/MixedPropertiesAndAdditionalPropertiesClassTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/MixedPropertiesAndAdditionalPropertiesClassTest.php
@@ -76,7 +76,7 @@ class MixedPropertiesAndAdditionalPropertiesClassTest extends TestCase
     public function testMixedPropertiesAndAdditionalPropertiesClass()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class MixedPropertiesAndAdditionalPropertiesClassTest extends TestCase
     public function testPropertyUuid()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,7 +94,7 @@ class MixedPropertiesAndAdditionalPropertiesClassTest extends TestCase
     public function testPropertyDateTime()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -103,6 +103,6 @@ class MixedPropertiesAndAdditionalPropertiesClassTest extends TestCase
     public function testPropertyMap()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/Model200ResponseTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/Model200ResponseTest.php
@@ -76,7 +76,7 @@ class Model200ResponseTest extends TestCase
     public function testModel200Response()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class Model200ResponseTest extends TestCase
     public function testPropertyName()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,6 +94,6 @@ class Model200ResponseTest extends TestCase
     public function testPropertyClass()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/ModelListTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/ModelListTest.php
@@ -76,7 +76,7 @@ class ModelListTest extends TestCase
     public function testModelList()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,6 +85,6 @@ class ModelListTest extends TestCase
     public function testProperty123List()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/ModelReturnTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/ModelReturnTest.php
@@ -76,7 +76,7 @@ class ModelReturnTest extends TestCase
     public function testModelReturn()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,6 +85,6 @@ class ModelReturnTest extends TestCase
     public function testPropertyReturn()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/NameTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/NameTest.php
@@ -76,7 +76,7 @@ class NameTest extends TestCase
     public function testName()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class NameTest extends TestCase
     public function testPropertyName()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,7 +94,7 @@ class NameTest extends TestCase
     public function testPropertySnakeCase()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -103,7 +103,7 @@ class NameTest extends TestCase
     public function testPropertyProperty()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -112,6 +112,6 @@ class NameTest extends TestCase
     public function testProperty123Number()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/NullableClassTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/NullableClassTest.php
@@ -76,7 +76,7 @@ class NullableClassTest extends TestCase
     public function testNullableClass()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class NullableClassTest extends TestCase
     public function testPropertyIntegerProp()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,7 +94,7 @@ class NullableClassTest extends TestCase
     public function testPropertyNumberProp()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -103,7 +103,7 @@ class NullableClassTest extends TestCase
     public function testPropertyBooleanProp()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -112,7 +112,7 @@ class NullableClassTest extends TestCase
     public function testPropertyStringProp()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -121,7 +121,7 @@ class NullableClassTest extends TestCase
     public function testPropertyDateProp()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -130,7 +130,7 @@ class NullableClassTest extends TestCase
     public function testPropertyDatetimeProp()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -139,7 +139,7 @@ class NullableClassTest extends TestCase
     public function testPropertyArrayNullableProp()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -148,7 +148,7 @@ class NullableClassTest extends TestCase
     public function testPropertyArrayAndItemsNullableProp()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -157,7 +157,7 @@ class NullableClassTest extends TestCase
     public function testPropertyArrayItemsNullable()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -166,7 +166,7 @@ class NullableClassTest extends TestCase
     public function testPropertyObjectNullableProp()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -175,7 +175,7 @@ class NullableClassTest extends TestCase
     public function testPropertyObjectAndItemsNullableProp()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -184,6 +184,6 @@ class NullableClassTest extends TestCase
     public function testPropertyObjectItemsNullable()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/NumberOnlyTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/NumberOnlyTest.php
@@ -76,7 +76,7 @@ class NumberOnlyTest extends TestCase
     public function testNumberOnly()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,6 +85,6 @@ class NumberOnlyTest extends TestCase
     public function testPropertyJustNumber()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/ObjectWithDeprecatedFieldsTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/ObjectWithDeprecatedFieldsTest.php
@@ -76,7 +76,7 @@ class ObjectWithDeprecatedFieldsTest extends TestCase
     public function testObjectWithDeprecatedFields()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class ObjectWithDeprecatedFieldsTest extends TestCase
     public function testPropertyUuid()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,7 +94,7 @@ class ObjectWithDeprecatedFieldsTest extends TestCase
     public function testPropertyId()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -103,7 +103,7 @@ class ObjectWithDeprecatedFieldsTest extends TestCase
     public function testPropertyDeprecatedRef()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -112,6 +112,6 @@ class ObjectWithDeprecatedFieldsTest extends TestCase
     public function testPropertyBars()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/OrderTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/OrderTest.php
@@ -76,7 +76,7 @@ class OrderTest extends TestCase
     public function testOrder()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class OrderTest extends TestCase
     public function testPropertyId()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,7 +94,7 @@ class OrderTest extends TestCase
     public function testPropertyPetId()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -103,7 +103,7 @@ class OrderTest extends TestCase
     public function testPropertyQuantity()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -112,7 +112,7 @@ class OrderTest extends TestCase
     public function testPropertyShipDate()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -121,7 +121,7 @@ class OrderTest extends TestCase
     public function testPropertyStatus()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -130,6 +130,6 @@ class OrderTest extends TestCase
     public function testPropertyComplete()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/OuterCompositeTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/OuterCompositeTest.php
@@ -76,7 +76,7 @@ class OuterCompositeTest extends TestCase
     public function testOuterComposite()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class OuterCompositeTest extends TestCase
     public function testPropertyMyNumber()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,7 +94,7 @@ class OuterCompositeTest extends TestCase
     public function testPropertyMyString()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -103,6 +103,6 @@ class OuterCompositeTest extends TestCase
     public function testPropertyMyBoolean()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/OuterEnumDefaultValueTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/OuterEnumDefaultValueTest.php
@@ -76,6 +76,6 @@ class OuterEnumDefaultValueTest extends TestCase
     public function testOuterEnumDefaultValue()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/OuterEnumIntegerDefaultValueTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/OuterEnumIntegerDefaultValueTest.php
@@ -76,6 +76,6 @@ class OuterEnumIntegerDefaultValueTest extends TestCase
     public function testOuterEnumIntegerDefaultValue()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/OuterEnumIntegerTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/OuterEnumIntegerTest.php
@@ -76,6 +76,6 @@ class OuterEnumIntegerTest extends TestCase
     public function testOuterEnumInteger()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/OuterEnumTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/OuterEnumTest.php
@@ -76,6 +76,6 @@ class OuterEnumTest extends TestCase
     public function testOuterEnum()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/OuterObjectWithEnumPropertyTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/OuterObjectWithEnumPropertyTest.php
@@ -76,7 +76,7 @@ class OuterObjectWithEnumPropertyTest extends TestCase
     public function testOuterObjectWithEnumProperty()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,6 +85,6 @@ class OuterObjectWithEnumPropertyTest extends TestCase
     public function testPropertyValue()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/ParentWithNullableTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/ParentWithNullableTest.php
@@ -76,7 +76,7 @@ class ParentWithNullableTest extends TestCase
     public function testParentWithNullable()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class ParentWithNullableTest extends TestCase
     public function testPropertyType()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,6 +94,6 @@ class ParentWithNullableTest extends TestCase
     public function testPropertyNullableProperty()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/PetTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/PetTest.php
@@ -76,7 +76,7 @@ class PetTest extends TestCase
     public function testPet()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class PetTest extends TestCase
     public function testPropertyId()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,7 +94,7 @@ class PetTest extends TestCase
     public function testPropertyCategory()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -103,7 +103,7 @@ class PetTest extends TestCase
     public function testPropertyName()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -112,7 +112,7 @@ class PetTest extends TestCase
     public function testPropertyPhotoUrls()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -121,7 +121,7 @@ class PetTest extends TestCase
     public function testPropertyTags()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -130,6 +130,6 @@ class PetTest extends TestCase
     public function testPropertyStatus()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/ReadOnlyFirstTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/ReadOnlyFirstTest.php
@@ -76,7 +76,7 @@ class ReadOnlyFirstTest extends TestCase
     public function testReadOnlyFirst()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class ReadOnlyFirstTest extends TestCase
     public function testPropertyBar()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,6 +94,6 @@ class ReadOnlyFirstTest extends TestCase
     public function testPropertyBaz()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/SingleRefTypeTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/SingleRefTypeTest.php
@@ -76,6 +76,6 @@ class SingleRefTypeTest extends TestCase
     public function testSingleRefType()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/SpecialModelNameTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/SpecialModelNameTest.php
@@ -76,7 +76,7 @@ class SpecialModelNameTest extends TestCase
     public function testSpecialModelName()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,6 +85,6 @@ class SpecialModelNameTest extends TestCase
     public function testPropertySpecialPropertyName()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/TagTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/TagTest.php
@@ -76,7 +76,7 @@ class TagTest extends TestCase
     public function testTag()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class TagTest extends TestCase
     public function testPropertyId()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,6 +94,6 @@ class TagTest extends TestCase
     public function testPropertyName()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/TestInlineFreeformAdditionalPropertiesRequestTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/TestInlineFreeformAdditionalPropertiesRequestTest.php
@@ -76,7 +76,7 @@ class TestInlineFreeformAdditionalPropertiesRequestTest extends TestCase
     public function testTestInlineFreeformAdditionalPropertiesRequest()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,6 +85,6 @@ class TestInlineFreeformAdditionalPropertiesRequestTest extends TestCase
     public function testPropertySomeProperty()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/UserTest.php
+++ b/samples/client/petstore/php-nextgen/OpenAPIClient-php/tests/Model/UserTest.php
@@ -76,7 +76,7 @@ class UserTest extends TestCase
     public function testUser()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class UserTest extends TestCase
     public function testPropertyId()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,7 +94,7 @@ class UserTest extends TestCase
     public function testPropertyUsername()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -103,7 +103,7 @@ class UserTest extends TestCase
     public function testPropertyFirstName()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -112,7 +112,7 @@ class UserTest extends TestCase
     public function testPropertyLastName()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -121,7 +121,7 @@ class UserTest extends TestCase
     public function testPropertyEmail()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -130,7 +130,7 @@ class UserTest extends TestCase
     public function testPropertyPassword()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -139,7 +139,7 @@ class UserTest extends TestCase
     public function testPropertyPhone()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -148,6 +148,6 @@ class UserTest extends TestCase
     public function testPropertyUserStatus()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/test/Api/AnotherFakeApiTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/test/Api/AnotherFakeApiTest.php
@@ -80,6 +80,6 @@ class AnotherFakeApiTest extends TestCase
     public function testCall123TestSpecialTags()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/test/Api/DefaultApiTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/test/Api/DefaultApiTest.php
@@ -80,6 +80,6 @@ class DefaultApiTest extends TestCase
     public function testFooGet()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/test/Api/FakeApiTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/test/Api/FakeApiTest.php
@@ -80,7 +80,7 @@ class FakeApiTest extends TestCase
     public function testFakeHealthGet()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -92,7 +92,7 @@ class FakeApiTest extends TestCase
     public function testFakeHttpSignatureTest()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -104,7 +104,7 @@ class FakeApiTest extends TestCase
     public function testFakeOuterBooleanSerialize()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -116,7 +116,7 @@ class FakeApiTest extends TestCase
     public function testFakeOuterCompositeSerialize()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -128,7 +128,7 @@ class FakeApiTest extends TestCase
     public function testFakeOuterNumberSerialize()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -140,7 +140,7 @@ class FakeApiTest extends TestCase
     public function testFakeOuterStringSerialize()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -152,7 +152,7 @@ class FakeApiTest extends TestCase
     public function testFakePropertyEnumIntegerSerialize()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -164,7 +164,7 @@ class FakeApiTest extends TestCase
     public function testTestBodyWithBinary()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -176,7 +176,7 @@ class FakeApiTest extends TestCase
     public function testTestBodyWithFileSchema()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -188,7 +188,7 @@ class FakeApiTest extends TestCase
     public function testTestBodyWithQueryParams()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -200,7 +200,7 @@ class FakeApiTest extends TestCase
     public function testTestClientModel()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -212,7 +212,7 @@ class FakeApiTest extends TestCase
     public function testTestEndpointParameters()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -224,7 +224,7 @@ class FakeApiTest extends TestCase
     public function testTestEnumParameters()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -236,7 +236,7 @@ class FakeApiTest extends TestCase
     public function testTestGroupParameters()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -248,7 +248,7 @@ class FakeApiTest extends TestCase
     public function testTestInlineAdditionalProperties()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -260,7 +260,7 @@ class FakeApiTest extends TestCase
     public function testTestJsonFormData()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -272,6 +272,6 @@ class FakeApiTest extends TestCase
     public function testTestQueryParameterCollectionFormat()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/test/Api/FakeClassnameTags123ApiTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/test/Api/FakeClassnameTags123ApiTest.php
@@ -80,6 +80,6 @@ class FakeClassnameTags123ApiTest extends TestCase
     public function testTestClassname()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/test/Api/PetApiTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/test/Api/PetApiTest.php
@@ -80,7 +80,7 @@ class PetApiTest extends TestCase
     public function testAddPet()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -92,7 +92,7 @@ class PetApiTest extends TestCase
     public function testDeletePet()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -104,7 +104,7 @@ class PetApiTest extends TestCase
     public function testFindPetsByStatus()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -116,7 +116,7 @@ class PetApiTest extends TestCase
     public function testFindPetsByTags()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -128,7 +128,7 @@ class PetApiTest extends TestCase
     public function testGetPetById()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -140,7 +140,7 @@ class PetApiTest extends TestCase
     public function testUpdatePet()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -152,7 +152,7 @@ class PetApiTest extends TestCase
     public function testUpdatePetWithForm()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -164,7 +164,7 @@ class PetApiTest extends TestCase
     public function testUploadFile()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -176,6 +176,6 @@ class PetApiTest extends TestCase
     public function testUploadFileWithRequiredFile()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/test/Api/StoreApiTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/test/Api/StoreApiTest.php
@@ -80,7 +80,7 @@ class StoreApiTest extends TestCase
     public function testDeleteOrder()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -92,7 +92,7 @@ class StoreApiTest extends TestCase
     public function testGetInventory()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -104,7 +104,7 @@ class StoreApiTest extends TestCase
     public function testGetOrderById()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -116,6 +116,6 @@ class StoreApiTest extends TestCase
     public function testPlaceOrder()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/test/Api/UserApiTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/test/Api/UserApiTest.php
@@ -80,7 +80,7 @@ class UserApiTest extends TestCase
     public function testCreateUser()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -92,7 +92,7 @@ class UserApiTest extends TestCase
     public function testCreateUsersWithArrayInput()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -104,7 +104,7 @@ class UserApiTest extends TestCase
     public function testCreateUsersWithListInput()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -116,7 +116,7 @@ class UserApiTest extends TestCase
     public function testDeleteUser()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -128,7 +128,7 @@ class UserApiTest extends TestCase
     public function testGetUserByName()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -140,7 +140,7 @@ class UserApiTest extends TestCase
     public function testLoginUser()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -152,7 +152,7 @@ class UserApiTest extends TestCase
     public function testLogoutUser()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -164,6 +164,6 @@ class UserApiTest extends TestCase
     public function testUpdateUser()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/test/Model/AdditionalPropertiesClassTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/test/Model/AdditionalPropertiesClassTest.php
@@ -76,7 +76,7 @@ class AdditionalPropertiesClassTest extends TestCase
     public function testAdditionalPropertiesClass()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class AdditionalPropertiesClassTest extends TestCase
     public function testPropertyMapProperty()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,6 +94,6 @@ class AdditionalPropertiesClassTest extends TestCase
     public function testPropertyMapOfMapProperty()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/test/Model/AllOfWithSingleRefTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/test/Model/AllOfWithSingleRefTest.php
@@ -76,7 +76,7 @@ class AllOfWithSingleRefTest extends TestCase
     public function testAllOfWithSingleRef()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class AllOfWithSingleRefTest extends TestCase
     public function testPropertyUsername()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,6 +94,6 @@ class AllOfWithSingleRefTest extends TestCase
     public function testPropertySingleRefType()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/test/Model/AnimalTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/test/Model/AnimalTest.php
@@ -76,7 +76,7 @@ class AnimalTest extends TestCase
     public function testAnimal()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class AnimalTest extends TestCase
     public function testPropertyClassName()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,6 +94,6 @@ class AnimalTest extends TestCase
     public function testPropertyColor()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/test/Model/ApiResponseTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/test/Model/ApiResponseTest.php
@@ -76,7 +76,7 @@ class ApiResponseTest extends TestCase
     public function testApiResponse()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class ApiResponseTest extends TestCase
     public function testPropertyCode()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,7 +94,7 @@ class ApiResponseTest extends TestCase
     public function testPropertyType()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -103,6 +103,6 @@ class ApiResponseTest extends TestCase
     public function testPropertyMessage()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/test/Model/ArrayOfArrayOfNumberOnlyTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/test/Model/ArrayOfArrayOfNumberOnlyTest.php
@@ -76,7 +76,7 @@ class ArrayOfArrayOfNumberOnlyTest extends TestCase
     public function testArrayOfArrayOfNumberOnly()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,6 +85,6 @@ class ArrayOfArrayOfNumberOnlyTest extends TestCase
     public function testPropertyArrayArrayNumber()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/test/Model/ArrayOfNumberOnlyTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/test/Model/ArrayOfNumberOnlyTest.php
@@ -76,7 +76,7 @@ class ArrayOfNumberOnlyTest extends TestCase
     public function testArrayOfNumberOnly()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,6 +85,6 @@ class ArrayOfNumberOnlyTest extends TestCase
     public function testPropertyArrayNumber()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/test/Model/ArrayTestTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/test/Model/ArrayTestTest.php
@@ -76,7 +76,7 @@ class ArrayTestTest extends TestCase
     public function testArrayTest()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class ArrayTestTest extends TestCase
     public function testPropertyArrayOfString()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,7 +94,7 @@ class ArrayTestTest extends TestCase
     public function testPropertyArrayArrayOfInteger()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -103,6 +103,6 @@ class ArrayTestTest extends TestCase
     public function testPropertyArrayArrayOfModel()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/test/Model/CapitalizationTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/test/Model/CapitalizationTest.php
@@ -76,7 +76,7 @@ class CapitalizationTest extends TestCase
     public function testCapitalization()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class CapitalizationTest extends TestCase
     public function testPropertySmallCamel()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,7 +94,7 @@ class CapitalizationTest extends TestCase
     public function testPropertyCapitalCamel()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -103,7 +103,7 @@ class CapitalizationTest extends TestCase
     public function testPropertySmallSnake()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -112,7 +112,7 @@ class CapitalizationTest extends TestCase
     public function testPropertyCapitalSnake()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -121,7 +121,7 @@ class CapitalizationTest extends TestCase
     public function testPropertyScaEthFlowPoints()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -130,6 +130,6 @@ class CapitalizationTest extends TestCase
     public function testPropertyAttName()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/test/Model/CatTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/test/Model/CatTest.php
@@ -76,7 +76,7 @@ class CatTest extends TestCase
     public function testCat()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,6 +85,6 @@ class CatTest extends TestCase
     public function testPropertyDeclawed()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/test/Model/CategoryTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/test/Model/CategoryTest.php
@@ -76,7 +76,7 @@ class CategoryTest extends TestCase
     public function testCategory()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class CategoryTest extends TestCase
     public function testPropertyId()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,6 +94,6 @@ class CategoryTest extends TestCase
     public function testPropertyName()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/test/Model/ClassModelTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/test/Model/ClassModelTest.php
@@ -76,7 +76,7 @@ class ClassModelTest extends TestCase
     public function testClassModel()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,6 +85,6 @@ class ClassModelTest extends TestCase
     public function testPropertyClass()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/test/Model/ClientTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/test/Model/ClientTest.php
@@ -76,7 +76,7 @@ class ClientTest extends TestCase
     public function testClient()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,6 +85,6 @@ class ClientTest extends TestCase
     public function testPropertyClient()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/test/Model/DeprecatedObjectTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/test/Model/DeprecatedObjectTest.php
@@ -76,7 +76,7 @@ class DeprecatedObjectTest extends TestCase
     public function testDeprecatedObject()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,6 +85,6 @@ class DeprecatedObjectTest extends TestCase
     public function testPropertyName()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/test/Model/DogTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/test/Model/DogTest.php
@@ -76,7 +76,7 @@ class DogTest extends TestCase
     public function testDog()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,6 +85,6 @@ class DogTest extends TestCase
     public function testPropertyBreed()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/test/Model/EnumArraysTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/test/Model/EnumArraysTest.php
@@ -76,7 +76,7 @@ class EnumArraysTest extends TestCase
     public function testEnumArrays()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class EnumArraysTest extends TestCase
     public function testPropertyJustSymbol()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,6 +94,6 @@ class EnumArraysTest extends TestCase
     public function testPropertyArrayEnum()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/test/Model/EnumClassTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/test/Model/EnumClassTest.php
@@ -76,6 +76,6 @@ class EnumClassTest extends TestCase
     public function testEnumClass()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/test/Model/EnumTestTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/test/Model/EnumTestTest.php
@@ -76,7 +76,7 @@ class EnumTestTest extends TestCase
     public function testEnumTest()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class EnumTestTest extends TestCase
     public function testPropertyEnumString()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,7 +94,7 @@ class EnumTestTest extends TestCase
     public function testPropertyEnumStringRequired()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -103,7 +103,7 @@ class EnumTestTest extends TestCase
     public function testPropertyEnumInteger()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -112,7 +112,7 @@ class EnumTestTest extends TestCase
     public function testPropertyEnumNumber()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -121,7 +121,7 @@ class EnumTestTest extends TestCase
     public function testPropertyOuterEnum()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -130,7 +130,7 @@ class EnumTestTest extends TestCase
     public function testPropertyOuterEnumInteger()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -139,7 +139,7 @@ class EnumTestTest extends TestCase
     public function testPropertyOuterEnumDefaultValue()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -148,6 +148,6 @@ class EnumTestTest extends TestCase
     public function testPropertyOuterEnumIntegerDefaultValue()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/test/Model/FakeBigDecimalMap200ResponseTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/test/Model/FakeBigDecimalMap200ResponseTest.php
@@ -76,7 +76,7 @@ class FakeBigDecimalMap200ResponseTest extends TestCase
     public function testFakeBigDecimalMap200Response()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class FakeBigDecimalMap200ResponseTest extends TestCase
     public function testPropertySomeId()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,6 +94,6 @@ class FakeBigDecimalMap200ResponseTest extends TestCase
     public function testPropertySomeMap()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/test/Model/FileSchemaTestClassTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/test/Model/FileSchemaTestClassTest.php
@@ -76,7 +76,7 @@ class FileSchemaTestClassTest extends TestCase
     public function testFileSchemaTestClass()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class FileSchemaTestClassTest extends TestCase
     public function testPropertyFile()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,6 +94,6 @@ class FileSchemaTestClassTest extends TestCase
     public function testPropertyFiles()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/test/Model/FileTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/test/Model/FileTest.php
@@ -76,7 +76,7 @@ class FileTest extends TestCase
     public function testFile()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,6 +85,6 @@ class FileTest extends TestCase
     public function testPropertySourceUri()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/test/Model/FooGetDefaultResponseTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/test/Model/FooGetDefaultResponseTest.php
@@ -76,7 +76,7 @@ class FooGetDefaultResponseTest extends TestCase
     public function testFooGetDefaultResponse()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,6 +85,6 @@ class FooGetDefaultResponseTest extends TestCase
     public function testPropertyString()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/test/Model/FooTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/test/Model/FooTest.php
@@ -76,7 +76,7 @@ class FooTest extends TestCase
     public function testFoo()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,6 +85,6 @@ class FooTest extends TestCase
     public function testPropertyBar()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/test/Model/FormatTestTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/test/Model/FormatTestTest.php
@@ -76,7 +76,7 @@ class FormatTestTest extends TestCase
     public function testFormatTest()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class FormatTestTest extends TestCase
     public function testPropertyInteger()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,7 +94,7 @@ class FormatTestTest extends TestCase
     public function testPropertyInt32()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -103,7 +103,7 @@ class FormatTestTest extends TestCase
     public function testPropertyInt64()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -112,7 +112,7 @@ class FormatTestTest extends TestCase
     public function testPropertyNumber()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -121,7 +121,7 @@ class FormatTestTest extends TestCase
     public function testPropertyFloat()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -130,7 +130,7 @@ class FormatTestTest extends TestCase
     public function testPropertyDouble()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -139,7 +139,7 @@ class FormatTestTest extends TestCase
     public function testPropertyDecimal()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -148,7 +148,7 @@ class FormatTestTest extends TestCase
     public function testPropertyString()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -157,7 +157,7 @@ class FormatTestTest extends TestCase
     public function testPropertyByte()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -166,7 +166,7 @@ class FormatTestTest extends TestCase
     public function testPropertyBinary()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -175,7 +175,7 @@ class FormatTestTest extends TestCase
     public function testPropertyDate()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -184,7 +184,7 @@ class FormatTestTest extends TestCase
     public function testPropertyDateTime()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -193,7 +193,7 @@ class FormatTestTest extends TestCase
     public function testPropertyUuid()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -202,7 +202,7 @@ class FormatTestTest extends TestCase
     public function testPropertyPassword()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -211,7 +211,7 @@ class FormatTestTest extends TestCase
     public function testPropertyPatternWithDigits()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -220,6 +220,6 @@ class FormatTestTest extends TestCase
     public function testPropertyPatternWithDigitsAndDelimiter()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/test/Model/HasOnlyReadOnlyTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/test/Model/HasOnlyReadOnlyTest.php
@@ -76,7 +76,7 @@ class HasOnlyReadOnlyTest extends TestCase
     public function testHasOnlyReadOnly()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class HasOnlyReadOnlyTest extends TestCase
     public function testPropertyBar()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,6 +94,6 @@ class HasOnlyReadOnlyTest extends TestCase
     public function testPropertyFoo()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/test/Model/HealthCheckResultTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/test/Model/HealthCheckResultTest.php
@@ -76,7 +76,7 @@ class HealthCheckResultTest extends TestCase
     public function testHealthCheckResult()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,6 +85,6 @@ class HealthCheckResultTest extends TestCase
     public function testPropertyNullableMessage()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/test/Model/MapTestTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/test/Model/MapTestTest.php
@@ -76,7 +76,7 @@ class MapTestTest extends TestCase
     public function testMapTest()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class MapTestTest extends TestCase
     public function testPropertyMapMapOfString()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,7 +94,7 @@ class MapTestTest extends TestCase
     public function testPropertyMapOfEnumString()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -103,7 +103,7 @@ class MapTestTest extends TestCase
     public function testPropertyDirectMap()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -112,6 +112,6 @@ class MapTestTest extends TestCase
     public function testPropertyIndirectMap()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/test/Model/MixedPropertiesAndAdditionalPropertiesClassTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/test/Model/MixedPropertiesAndAdditionalPropertiesClassTest.php
@@ -76,7 +76,7 @@ class MixedPropertiesAndAdditionalPropertiesClassTest extends TestCase
     public function testMixedPropertiesAndAdditionalPropertiesClass()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class MixedPropertiesAndAdditionalPropertiesClassTest extends TestCase
     public function testPropertyUuid()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,7 +94,7 @@ class MixedPropertiesAndAdditionalPropertiesClassTest extends TestCase
     public function testPropertyDateTime()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -103,6 +103,6 @@ class MixedPropertiesAndAdditionalPropertiesClassTest extends TestCase
     public function testPropertyMap()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/test/Model/Model200ResponseTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/test/Model/Model200ResponseTest.php
@@ -76,7 +76,7 @@ class Model200ResponseTest extends TestCase
     public function testModel200Response()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class Model200ResponseTest extends TestCase
     public function testPropertyName()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,6 +94,6 @@ class Model200ResponseTest extends TestCase
     public function testPropertyClass()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/test/Model/ModelListTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/test/Model/ModelListTest.php
@@ -76,7 +76,7 @@ class ModelListTest extends TestCase
     public function testModelList()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,6 +85,6 @@ class ModelListTest extends TestCase
     public function testProperty123List()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/test/Model/ModelReturnTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/test/Model/ModelReturnTest.php
@@ -76,7 +76,7 @@ class ModelReturnTest extends TestCase
     public function testModelReturn()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,6 +85,6 @@ class ModelReturnTest extends TestCase
     public function testPropertyReturn()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/test/Model/NameTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/test/Model/NameTest.php
@@ -76,7 +76,7 @@ class NameTest extends TestCase
     public function testName()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class NameTest extends TestCase
     public function testPropertyName()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,7 +94,7 @@ class NameTest extends TestCase
     public function testPropertySnakeCase()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -103,7 +103,7 @@ class NameTest extends TestCase
     public function testPropertyProperty()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -112,6 +112,6 @@ class NameTest extends TestCase
     public function testProperty123Number()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/test/Model/NullableClassTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/test/Model/NullableClassTest.php
@@ -76,7 +76,7 @@ class NullableClassTest extends TestCase
     public function testNullableClass()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class NullableClassTest extends TestCase
     public function testPropertyIntegerProp()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,7 +94,7 @@ class NullableClassTest extends TestCase
     public function testPropertyNumberProp()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -103,7 +103,7 @@ class NullableClassTest extends TestCase
     public function testPropertyBooleanProp()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -112,7 +112,7 @@ class NullableClassTest extends TestCase
     public function testPropertyStringProp()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -121,7 +121,7 @@ class NullableClassTest extends TestCase
     public function testPropertyDateProp()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -130,7 +130,7 @@ class NullableClassTest extends TestCase
     public function testPropertyDatetimeProp()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -139,7 +139,7 @@ class NullableClassTest extends TestCase
     public function testPropertyArrayNullableProp()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -148,7 +148,7 @@ class NullableClassTest extends TestCase
     public function testPropertyArrayAndItemsNullableProp()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -157,7 +157,7 @@ class NullableClassTest extends TestCase
     public function testPropertyArrayItemsNullable()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -166,7 +166,7 @@ class NullableClassTest extends TestCase
     public function testPropertyObjectNullableProp()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -175,7 +175,7 @@ class NullableClassTest extends TestCase
     public function testPropertyObjectAndItemsNullableProp()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -184,6 +184,6 @@ class NullableClassTest extends TestCase
     public function testPropertyObjectItemsNullable()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/test/Model/NumberOnlyTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/test/Model/NumberOnlyTest.php
@@ -76,7 +76,7 @@ class NumberOnlyTest extends TestCase
     public function testNumberOnly()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,6 +85,6 @@ class NumberOnlyTest extends TestCase
     public function testPropertyJustNumber()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/test/Model/ObjectWithDeprecatedFieldsTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/test/Model/ObjectWithDeprecatedFieldsTest.php
@@ -76,7 +76,7 @@ class ObjectWithDeprecatedFieldsTest extends TestCase
     public function testObjectWithDeprecatedFields()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class ObjectWithDeprecatedFieldsTest extends TestCase
     public function testPropertyUuid()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,7 +94,7 @@ class ObjectWithDeprecatedFieldsTest extends TestCase
     public function testPropertyId()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -103,7 +103,7 @@ class ObjectWithDeprecatedFieldsTest extends TestCase
     public function testPropertyDeprecatedRef()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -112,6 +112,6 @@ class ObjectWithDeprecatedFieldsTest extends TestCase
     public function testPropertyBars()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/test/Model/OrderTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/test/Model/OrderTest.php
@@ -76,7 +76,7 @@ class OrderTest extends TestCase
     public function testOrder()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class OrderTest extends TestCase
     public function testPropertyId()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,7 +94,7 @@ class OrderTest extends TestCase
     public function testPropertyPetId()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -103,7 +103,7 @@ class OrderTest extends TestCase
     public function testPropertyQuantity()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -112,7 +112,7 @@ class OrderTest extends TestCase
     public function testPropertyShipDate()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -121,7 +121,7 @@ class OrderTest extends TestCase
     public function testPropertyStatus()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -130,6 +130,6 @@ class OrderTest extends TestCase
     public function testPropertyComplete()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/test/Model/OuterCompositeTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/test/Model/OuterCompositeTest.php
@@ -76,7 +76,7 @@ class OuterCompositeTest extends TestCase
     public function testOuterComposite()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class OuterCompositeTest extends TestCase
     public function testPropertyMyNumber()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,7 +94,7 @@ class OuterCompositeTest extends TestCase
     public function testPropertyMyString()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -103,6 +103,6 @@ class OuterCompositeTest extends TestCase
     public function testPropertyMyBoolean()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/test/Model/OuterEnumDefaultValueTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/test/Model/OuterEnumDefaultValueTest.php
@@ -76,6 +76,6 @@ class OuterEnumDefaultValueTest extends TestCase
     public function testOuterEnumDefaultValue()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/test/Model/OuterEnumIntegerDefaultValueTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/test/Model/OuterEnumIntegerDefaultValueTest.php
@@ -76,6 +76,6 @@ class OuterEnumIntegerDefaultValueTest extends TestCase
     public function testOuterEnumIntegerDefaultValue()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/test/Model/OuterEnumIntegerTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/test/Model/OuterEnumIntegerTest.php
@@ -76,6 +76,6 @@ class OuterEnumIntegerTest extends TestCase
     public function testOuterEnumInteger()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/test/Model/OuterEnumTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/test/Model/OuterEnumTest.php
@@ -76,6 +76,6 @@ class OuterEnumTest extends TestCase
     public function testOuterEnum()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/test/Model/OuterObjectWithEnumPropertyTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/test/Model/OuterObjectWithEnumPropertyTest.php
@@ -76,7 +76,7 @@ class OuterObjectWithEnumPropertyTest extends TestCase
     public function testOuterObjectWithEnumProperty()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,6 +85,6 @@ class OuterObjectWithEnumPropertyTest extends TestCase
     public function testPropertyValue()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/test/Model/PetTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/test/Model/PetTest.php
@@ -76,7 +76,7 @@ class PetTest extends TestCase
     public function testPet()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class PetTest extends TestCase
     public function testPropertyId()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,7 +94,7 @@ class PetTest extends TestCase
     public function testPropertyCategory()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -103,7 +103,7 @@ class PetTest extends TestCase
     public function testPropertyName()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -112,7 +112,7 @@ class PetTest extends TestCase
     public function testPropertyPhotoUrls()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -121,7 +121,7 @@ class PetTest extends TestCase
     public function testPropertyTags()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -130,6 +130,6 @@ class PetTest extends TestCase
     public function testPropertyStatus()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/test/Model/PropertyNameMappingTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/test/Model/PropertyNameMappingTest.php
@@ -76,7 +76,7 @@ class PropertyNameMappingTest extends TestCase
     public function testPropertyNameMapping()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class PropertyNameMappingTest extends TestCase
     public function testPropertyHttpDebugOperation()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,7 +94,7 @@ class PropertyNameMappingTest extends TestCase
     public function testPropertyUnderscoreType()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -103,7 +103,7 @@ class PropertyNameMappingTest extends TestCase
     public function testPropertyType()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -112,6 +112,6 @@ class PropertyNameMappingTest extends TestCase
     public function testPropertyTypeWithUnderscore()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/test/Model/ReadOnlyFirstTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/test/Model/ReadOnlyFirstTest.php
@@ -76,7 +76,7 @@ class ReadOnlyFirstTest extends TestCase
     public function testReadOnlyFirst()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class ReadOnlyFirstTest extends TestCase
     public function testPropertyBar()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,6 +94,6 @@ class ReadOnlyFirstTest extends TestCase
     public function testPropertyBaz()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/test/Model/SingleRefTypeTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/test/Model/SingleRefTypeTest.php
@@ -76,6 +76,6 @@ class SingleRefTypeTest extends TestCase
     public function testSingleRefType()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/test/Model/SpecialModelNameTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/test/Model/SpecialModelNameTest.php
@@ -76,7 +76,7 @@ class SpecialModelNameTest extends TestCase
     public function testSpecialModelName()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,6 +85,6 @@ class SpecialModelNameTest extends TestCase
     public function testPropertySpecialPropertyName()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/test/Model/TagTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/test/Model/TagTest.php
@@ -76,7 +76,7 @@ class TagTest extends TestCase
     public function testTag()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class TagTest extends TestCase
     public function testPropertyId()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,6 +94,6 @@ class TagTest extends TestCase
     public function testPropertyName()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/test/Model/TestInlineFreeformAdditionalPropertiesRequestTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/test/Model/TestInlineFreeformAdditionalPropertiesRequestTest.php
@@ -76,7 +76,7 @@ class TestInlineFreeformAdditionalPropertiesRequestTest extends TestCase
     public function testTestInlineFreeformAdditionalPropertiesRequest()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,6 +85,6 @@ class TestInlineFreeformAdditionalPropertiesRequestTest extends TestCase
     public function testPropertySomeProperty()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/OpenAPIClient-php/test/Model/UserTest.php
+++ b/samples/client/petstore/php/OpenAPIClient-php/test/Model/UserTest.php
@@ -76,7 +76,7 @@ class UserTest extends TestCase
     public function testUser()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class UserTest extends TestCase
     public function testPropertyId()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,7 +94,7 @@ class UserTest extends TestCase
     public function testPropertyUsername()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -103,7 +103,7 @@ class UserTest extends TestCase
     public function testPropertyFirstName()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -112,7 +112,7 @@ class UserTest extends TestCase
     public function testPropertyLastName()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -121,7 +121,7 @@ class UserTest extends TestCase
     public function testPropertyEmail()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -130,7 +130,7 @@ class UserTest extends TestCase
     public function testPropertyPassword()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -139,7 +139,7 @@ class UserTest extends TestCase
     public function testPropertyPhone()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -148,6 +148,6 @@ class UserTest extends TestCase
     public function testPropertyUserStatus()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/psr-18/test/Api/AnotherFakeApiTest.php
+++ b/samples/client/petstore/php/psr-18/test/Api/AnotherFakeApiTest.php
@@ -80,6 +80,6 @@ class AnotherFakeApiTest extends TestCase
     public function testCall123TestSpecialTags()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/psr-18/test/Api/DefaultApiTest.php
+++ b/samples/client/petstore/php/psr-18/test/Api/DefaultApiTest.php
@@ -80,6 +80,6 @@ class DefaultApiTest extends TestCase
     public function testFooGet()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/psr-18/test/Api/FakeApiTest.php
+++ b/samples/client/petstore/php/psr-18/test/Api/FakeApiTest.php
@@ -80,7 +80,7 @@ class FakeApiTest extends TestCase
     public function testFakeBigDecimalMap()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -92,7 +92,7 @@ class FakeApiTest extends TestCase
     public function testFakeHealthGet()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -104,7 +104,7 @@ class FakeApiTest extends TestCase
     public function testFakeHttpSignatureTest()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -116,7 +116,7 @@ class FakeApiTest extends TestCase
     public function testFakeOuterBooleanSerialize()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -128,7 +128,7 @@ class FakeApiTest extends TestCase
     public function testFakeOuterCompositeSerialize()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -140,7 +140,7 @@ class FakeApiTest extends TestCase
     public function testFakeOuterNumberSerialize()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -152,7 +152,7 @@ class FakeApiTest extends TestCase
     public function testFakeOuterStringSerialize()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -164,7 +164,7 @@ class FakeApiTest extends TestCase
     public function testFakePropertyEnumIntegerSerialize()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -176,7 +176,7 @@ class FakeApiTest extends TestCase
     public function testGetParameterNameMapping()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -188,7 +188,7 @@ class FakeApiTest extends TestCase
     public function testTestBodyWithBinary()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -200,7 +200,7 @@ class FakeApiTest extends TestCase
     public function testTestBodyWithFileSchema()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -212,7 +212,7 @@ class FakeApiTest extends TestCase
     public function testTestBodyWithQueryParams()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -224,7 +224,7 @@ class FakeApiTest extends TestCase
     public function testTestClientModel()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -236,7 +236,7 @@ class FakeApiTest extends TestCase
     public function testTestEndpointParameters()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -248,7 +248,7 @@ class FakeApiTest extends TestCase
     public function testTestEnumParameters()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -260,7 +260,7 @@ class FakeApiTest extends TestCase
     public function testTestGroupParameters()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -272,7 +272,7 @@ class FakeApiTest extends TestCase
     public function testTestInlineAdditionalProperties()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -284,7 +284,7 @@ class FakeApiTest extends TestCase
     public function testTestJsonFormData()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -296,6 +296,6 @@ class FakeApiTest extends TestCase
     public function testTestQueryParameterCollectionFormat()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/psr-18/test/Api/FakeClassnameTags123ApiTest.php
+++ b/samples/client/petstore/php/psr-18/test/Api/FakeClassnameTags123ApiTest.php
@@ -80,6 +80,6 @@ class FakeClassnameTags123ApiTest extends TestCase
     public function testTestClassname()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/psr-18/test/Api/PetApiTest.php
+++ b/samples/client/petstore/php/psr-18/test/Api/PetApiTest.php
@@ -80,7 +80,7 @@ class PetApiTest extends TestCase
     public function testAddPet()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -92,7 +92,7 @@ class PetApiTest extends TestCase
     public function testDeletePet()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -104,7 +104,7 @@ class PetApiTest extends TestCase
     public function testFindPetsByStatus()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -116,7 +116,7 @@ class PetApiTest extends TestCase
     public function testFindPetsByTags()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -128,7 +128,7 @@ class PetApiTest extends TestCase
     public function testGetPetById()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -140,7 +140,7 @@ class PetApiTest extends TestCase
     public function testUpdatePet()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -152,7 +152,7 @@ class PetApiTest extends TestCase
     public function testUpdatePetWithForm()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -164,7 +164,7 @@ class PetApiTest extends TestCase
     public function testUploadFile()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -176,6 +176,6 @@ class PetApiTest extends TestCase
     public function testUploadFileWithRequiredFile()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/psr-18/test/Api/StoreApiTest.php
+++ b/samples/client/petstore/php/psr-18/test/Api/StoreApiTest.php
@@ -80,7 +80,7 @@ class StoreApiTest extends TestCase
     public function testDeleteOrder()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -92,7 +92,7 @@ class StoreApiTest extends TestCase
     public function testGetInventory()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -104,7 +104,7 @@ class StoreApiTest extends TestCase
     public function testGetOrderById()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -116,6 +116,6 @@ class StoreApiTest extends TestCase
     public function testPlaceOrder()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/psr-18/test/Api/UserApiTest.php
+++ b/samples/client/petstore/php/psr-18/test/Api/UserApiTest.php
@@ -80,7 +80,7 @@ class UserApiTest extends TestCase
     public function testCreateUser()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -92,7 +92,7 @@ class UserApiTest extends TestCase
     public function testCreateUsersWithArrayInput()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -104,7 +104,7 @@ class UserApiTest extends TestCase
     public function testCreateUsersWithListInput()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -116,7 +116,7 @@ class UserApiTest extends TestCase
     public function testDeleteUser()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -128,7 +128,7 @@ class UserApiTest extends TestCase
     public function testGetUserByName()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -140,7 +140,7 @@ class UserApiTest extends TestCase
     public function testLoginUser()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -152,7 +152,7 @@ class UserApiTest extends TestCase
     public function testLogoutUser()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -164,6 +164,6 @@ class UserApiTest extends TestCase
     public function testUpdateUser()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/psr-18/test/Model/AdditionalPropertiesClassTest.php
+++ b/samples/client/petstore/php/psr-18/test/Model/AdditionalPropertiesClassTest.php
@@ -76,7 +76,7 @@ class AdditionalPropertiesClassTest extends TestCase
     public function testAdditionalPropertiesClass()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class AdditionalPropertiesClassTest extends TestCase
     public function testPropertyMapProperty()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,6 +94,6 @@ class AdditionalPropertiesClassTest extends TestCase
     public function testPropertyMapOfMapProperty()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/psr-18/test/Model/AllOfWithSingleRefTest.php
+++ b/samples/client/petstore/php/psr-18/test/Model/AllOfWithSingleRefTest.php
@@ -76,7 +76,7 @@ class AllOfWithSingleRefTest extends TestCase
     public function testAllOfWithSingleRef()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class AllOfWithSingleRefTest extends TestCase
     public function testPropertyUsername()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,6 +94,6 @@ class AllOfWithSingleRefTest extends TestCase
     public function testPropertySingleRefType()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/psr-18/test/Model/AnimalTest.php
+++ b/samples/client/petstore/php/psr-18/test/Model/AnimalTest.php
@@ -76,7 +76,7 @@ class AnimalTest extends TestCase
     public function testAnimal()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class AnimalTest extends TestCase
     public function testPropertyClassName()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,6 +94,6 @@ class AnimalTest extends TestCase
     public function testPropertyColor()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/psr-18/test/Model/ApiResponseTest.php
+++ b/samples/client/petstore/php/psr-18/test/Model/ApiResponseTest.php
@@ -76,7 +76,7 @@ class ApiResponseTest extends TestCase
     public function testApiResponse()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class ApiResponseTest extends TestCase
     public function testPropertyCode()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,7 +94,7 @@ class ApiResponseTest extends TestCase
     public function testPropertyType()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -103,6 +103,6 @@ class ApiResponseTest extends TestCase
     public function testPropertyMessage()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/psr-18/test/Model/ArrayOfArrayOfNumberOnlyTest.php
+++ b/samples/client/petstore/php/psr-18/test/Model/ArrayOfArrayOfNumberOnlyTest.php
@@ -76,7 +76,7 @@ class ArrayOfArrayOfNumberOnlyTest extends TestCase
     public function testArrayOfArrayOfNumberOnly()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,6 +85,6 @@ class ArrayOfArrayOfNumberOnlyTest extends TestCase
     public function testPropertyArrayArrayNumber()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/psr-18/test/Model/ArrayOfNumberOnlyTest.php
+++ b/samples/client/petstore/php/psr-18/test/Model/ArrayOfNumberOnlyTest.php
@@ -76,7 +76,7 @@ class ArrayOfNumberOnlyTest extends TestCase
     public function testArrayOfNumberOnly()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,6 +85,6 @@ class ArrayOfNumberOnlyTest extends TestCase
     public function testPropertyArrayNumber()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/psr-18/test/Model/ArrayTestTest.php
+++ b/samples/client/petstore/php/psr-18/test/Model/ArrayTestTest.php
@@ -76,7 +76,7 @@ class ArrayTestTest extends TestCase
     public function testArrayTest()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class ArrayTestTest extends TestCase
     public function testPropertyArrayOfString()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,7 +94,7 @@ class ArrayTestTest extends TestCase
     public function testPropertyArrayArrayOfInteger()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -103,6 +103,6 @@ class ArrayTestTest extends TestCase
     public function testPropertyArrayArrayOfModel()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/psr-18/test/Model/CapitalizationTest.php
+++ b/samples/client/petstore/php/psr-18/test/Model/CapitalizationTest.php
@@ -76,7 +76,7 @@ class CapitalizationTest extends TestCase
     public function testCapitalization()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class CapitalizationTest extends TestCase
     public function testPropertySmallCamel()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,7 +94,7 @@ class CapitalizationTest extends TestCase
     public function testPropertyCapitalCamel()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -103,7 +103,7 @@ class CapitalizationTest extends TestCase
     public function testPropertySmallSnake()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -112,7 +112,7 @@ class CapitalizationTest extends TestCase
     public function testPropertyCapitalSnake()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -121,7 +121,7 @@ class CapitalizationTest extends TestCase
     public function testPropertyScaEthFlowPoints()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -130,6 +130,6 @@ class CapitalizationTest extends TestCase
     public function testPropertyAttName()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/psr-18/test/Model/CatTest.php
+++ b/samples/client/petstore/php/psr-18/test/Model/CatTest.php
@@ -76,7 +76,7 @@ class CatTest extends TestCase
     public function testCat()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,6 +85,6 @@ class CatTest extends TestCase
     public function testPropertyDeclawed()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/psr-18/test/Model/CategoryTest.php
+++ b/samples/client/petstore/php/psr-18/test/Model/CategoryTest.php
@@ -76,7 +76,7 @@ class CategoryTest extends TestCase
     public function testCategory()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class CategoryTest extends TestCase
     public function testPropertyId()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,6 +94,6 @@ class CategoryTest extends TestCase
     public function testPropertyName()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/psr-18/test/Model/ClassModelTest.php
+++ b/samples/client/petstore/php/psr-18/test/Model/ClassModelTest.php
@@ -76,7 +76,7 @@ class ClassModelTest extends TestCase
     public function testClassModel()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,6 +85,6 @@ class ClassModelTest extends TestCase
     public function testPropertyClass()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/psr-18/test/Model/ClientTest.php
+++ b/samples/client/petstore/php/psr-18/test/Model/ClientTest.php
@@ -76,7 +76,7 @@ class ClientTest extends TestCase
     public function testClient()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,6 +85,6 @@ class ClientTest extends TestCase
     public function testPropertyClient()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/psr-18/test/Model/DeprecatedObjectTest.php
+++ b/samples/client/petstore/php/psr-18/test/Model/DeprecatedObjectTest.php
@@ -76,7 +76,7 @@ class DeprecatedObjectTest extends TestCase
     public function testDeprecatedObject()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,6 +85,6 @@ class DeprecatedObjectTest extends TestCase
     public function testPropertyName()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/psr-18/test/Model/DogTest.php
+++ b/samples/client/petstore/php/psr-18/test/Model/DogTest.php
@@ -76,7 +76,7 @@ class DogTest extends TestCase
     public function testDog()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,6 +85,6 @@ class DogTest extends TestCase
     public function testPropertyBreed()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/psr-18/test/Model/EnumArraysTest.php
+++ b/samples/client/petstore/php/psr-18/test/Model/EnumArraysTest.php
@@ -76,7 +76,7 @@ class EnumArraysTest extends TestCase
     public function testEnumArrays()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class EnumArraysTest extends TestCase
     public function testPropertyJustSymbol()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,6 +94,6 @@ class EnumArraysTest extends TestCase
     public function testPropertyArrayEnum()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/psr-18/test/Model/EnumClassTest.php
+++ b/samples/client/petstore/php/psr-18/test/Model/EnumClassTest.php
@@ -76,6 +76,6 @@ class EnumClassTest extends TestCase
     public function testEnumClass()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/psr-18/test/Model/EnumTestTest.php
+++ b/samples/client/petstore/php/psr-18/test/Model/EnumTestTest.php
@@ -76,7 +76,7 @@ class EnumTestTest extends TestCase
     public function testEnumTest()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class EnumTestTest extends TestCase
     public function testPropertyEnumString()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,7 +94,7 @@ class EnumTestTest extends TestCase
     public function testPropertyEnumStringRequired()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -103,7 +103,7 @@ class EnumTestTest extends TestCase
     public function testPropertyEnumInteger()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -112,7 +112,7 @@ class EnumTestTest extends TestCase
     public function testPropertyEnumNumber()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -121,7 +121,7 @@ class EnumTestTest extends TestCase
     public function testPropertyOuterEnum()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -130,7 +130,7 @@ class EnumTestTest extends TestCase
     public function testPropertyOuterEnumInteger()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -139,7 +139,7 @@ class EnumTestTest extends TestCase
     public function testPropertyOuterEnumDefaultValue()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -148,6 +148,6 @@ class EnumTestTest extends TestCase
     public function testPropertyOuterEnumIntegerDefaultValue()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/psr-18/test/Model/FakeBigDecimalMap200ResponseTest.php
+++ b/samples/client/petstore/php/psr-18/test/Model/FakeBigDecimalMap200ResponseTest.php
@@ -76,7 +76,7 @@ class FakeBigDecimalMap200ResponseTest extends TestCase
     public function testFakeBigDecimalMap200Response()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class FakeBigDecimalMap200ResponseTest extends TestCase
     public function testPropertySomeId()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,6 +94,6 @@ class FakeBigDecimalMap200ResponseTest extends TestCase
     public function testPropertySomeMap()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/psr-18/test/Model/FileSchemaTestClassTest.php
+++ b/samples/client/petstore/php/psr-18/test/Model/FileSchemaTestClassTest.php
@@ -76,7 +76,7 @@ class FileSchemaTestClassTest extends TestCase
     public function testFileSchemaTestClass()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class FileSchemaTestClassTest extends TestCase
     public function testPropertyFile()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,6 +94,6 @@ class FileSchemaTestClassTest extends TestCase
     public function testPropertyFiles()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/psr-18/test/Model/FileTest.php
+++ b/samples/client/petstore/php/psr-18/test/Model/FileTest.php
@@ -76,7 +76,7 @@ class FileTest extends TestCase
     public function testFile()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,6 +85,6 @@ class FileTest extends TestCase
     public function testPropertySourceUri()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/psr-18/test/Model/FooGetDefaultResponseTest.php
+++ b/samples/client/petstore/php/psr-18/test/Model/FooGetDefaultResponseTest.php
@@ -76,7 +76,7 @@ class FooGetDefaultResponseTest extends TestCase
     public function testFooGetDefaultResponse()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,6 +85,6 @@ class FooGetDefaultResponseTest extends TestCase
     public function testPropertyString()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/psr-18/test/Model/FooTest.php
+++ b/samples/client/petstore/php/psr-18/test/Model/FooTest.php
@@ -76,7 +76,7 @@ class FooTest extends TestCase
     public function testFoo()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,6 +85,6 @@ class FooTest extends TestCase
     public function testPropertyBar()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/psr-18/test/Model/FormatTestTest.php
+++ b/samples/client/petstore/php/psr-18/test/Model/FormatTestTest.php
@@ -76,7 +76,7 @@ class FormatTestTest extends TestCase
     public function testFormatTest()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class FormatTestTest extends TestCase
     public function testPropertyInteger()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,7 +94,7 @@ class FormatTestTest extends TestCase
     public function testPropertyInt32()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -103,7 +103,7 @@ class FormatTestTest extends TestCase
     public function testPropertyInt64()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -112,7 +112,7 @@ class FormatTestTest extends TestCase
     public function testPropertyNumber()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -121,7 +121,7 @@ class FormatTestTest extends TestCase
     public function testPropertyFloat()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -130,7 +130,7 @@ class FormatTestTest extends TestCase
     public function testPropertyDouble()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -139,7 +139,7 @@ class FormatTestTest extends TestCase
     public function testPropertyDecimal()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -148,7 +148,7 @@ class FormatTestTest extends TestCase
     public function testPropertyString()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -157,7 +157,7 @@ class FormatTestTest extends TestCase
     public function testPropertyByte()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -166,7 +166,7 @@ class FormatTestTest extends TestCase
     public function testPropertyBinary()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -175,7 +175,7 @@ class FormatTestTest extends TestCase
     public function testPropertyDate()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -184,7 +184,7 @@ class FormatTestTest extends TestCase
     public function testPropertyDateTime()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -193,7 +193,7 @@ class FormatTestTest extends TestCase
     public function testPropertyUuid()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -202,7 +202,7 @@ class FormatTestTest extends TestCase
     public function testPropertyPassword()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -211,7 +211,7 @@ class FormatTestTest extends TestCase
     public function testPropertyPatternWithDigits()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -220,6 +220,6 @@ class FormatTestTest extends TestCase
     public function testPropertyPatternWithDigitsAndDelimiter()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/psr-18/test/Model/HasOnlyReadOnlyTest.php
+++ b/samples/client/petstore/php/psr-18/test/Model/HasOnlyReadOnlyTest.php
@@ -76,7 +76,7 @@ class HasOnlyReadOnlyTest extends TestCase
     public function testHasOnlyReadOnly()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class HasOnlyReadOnlyTest extends TestCase
     public function testPropertyBar()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,6 +94,6 @@ class HasOnlyReadOnlyTest extends TestCase
     public function testPropertyFoo()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/psr-18/test/Model/HealthCheckResultTest.php
+++ b/samples/client/petstore/php/psr-18/test/Model/HealthCheckResultTest.php
@@ -76,7 +76,7 @@ class HealthCheckResultTest extends TestCase
     public function testHealthCheckResult()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,6 +85,6 @@ class HealthCheckResultTest extends TestCase
     public function testPropertyNullableMessage()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/psr-18/test/Model/MapTestTest.php
+++ b/samples/client/petstore/php/psr-18/test/Model/MapTestTest.php
@@ -76,7 +76,7 @@ class MapTestTest extends TestCase
     public function testMapTest()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class MapTestTest extends TestCase
     public function testPropertyMapMapOfString()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,7 +94,7 @@ class MapTestTest extends TestCase
     public function testPropertyMapOfEnumString()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -103,7 +103,7 @@ class MapTestTest extends TestCase
     public function testPropertyDirectMap()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -112,6 +112,6 @@ class MapTestTest extends TestCase
     public function testPropertyIndirectMap()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/psr-18/test/Model/MixedPropertiesAndAdditionalPropertiesClassTest.php
+++ b/samples/client/petstore/php/psr-18/test/Model/MixedPropertiesAndAdditionalPropertiesClassTest.php
@@ -76,7 +76,7 @@ class MixedPropertiesAndAdditionalPropertiesClassTest extends TestCase
     public function testMixedPropertiesAndAdditionalPropertiesClass()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class MixedPropertiesAndAdditionalPropertiesClassTest extends TestCase
     public function testPropertyUuid()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,7 +94,7 @@ class MixedPropertiesAndAdditionalPropertiesClassTest extends TestCase
     public function testPropertyDateTime()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -103,6 +103,6 @@ class MixedPropertiesAndAdditionalPropertiesClassTest extends TestCase
     public function testPropertyMap()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/psr-18/test/Model/Model200ResponseTest.php
+++ b/samples/client/petstore/php/psr-18/test/Model/Model200ResponseTest.php
@@ -76,7 +76,7 @@ class Model200ResponseTest extends TestCase
     public function testModel200Response()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class Model200ResponseTest extends TestCase
     public function testPropertyName()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,6 +94,6 @@ class Model200ResponseTest extends TestCase
     public function testPropertyClass()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/psr-18/test/Model/ModelListTest.php
+++ b/samples/client/petstore/php/psr-18/test/Model/ModelListTest.php
@@ -76,7 +76,7 @@ class ModelListTest extends TestCase
     public function testModelList()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,6 +85,6 @@ class ModelListTest extends TestCase
     public function testProperty123List()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/psr-18/test/Model/ModelReturnTest.php
+++ b/samples/client/petstore/php/psr-18/test/Model/ModelReturnTest.php
@@ -76,7 +76,7 @@ class ModelReturnTest extends TestCase
     public function testModelReturn()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,6 +85,6 @@ class ModelReturnTest extends TestCase
     public function testPropertyReturn()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/psr-18/test/Model/NameTest.php
+++ b/samples/client/petstore/php/psr-18/test/Model/NameTest.php
@@ -76,7 +76,7 @@ class NameTest extends TestCase
     public function testName()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class NameTest extends TestCase
     public function testPropertyName()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,7 +94,7 @@ class NameTest extends TestCase
     public function testPropertySnakeCase()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -103,7 +103,7 @@ class NameTest extends TestCase
     public function testPropertyProperty()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -112,6 +112,6 @@ class NameTest extends TestCase
     public function testProperty123Number()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/psr-18/test/Model/NullableClassTest.php
+++ b/samples/client/petstore/php/psr-18/test/Model/NullableClassTest.php
@@ -76,7 +76,7 @@ class NullableClassTest extends TestCase
     public function testNullableClass()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class NullableClassTest extends TestCase
     public function testPropertyIntegerProp()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,7 +94,7 @@ class NullableClassTest extends TestCase
     public function testPropertyNumberProp()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -103,7 +103,7 @@ class NullableClassTest extends TestCase
     public function testPropertyBooleanProp()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -112,7 +112,7 @@ class NullableClassTest extends TestCase
     public function testPropertyStringProp()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -121,7 +121,7 @@ class NullableClassTest extends TestCase
     public function testPropertyDateProp()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -130,7 +130,7 @@ class NullableClassTest extends TestCase
     public function testPropertyDatetimeProp()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -139,7 +139,7 @@ class NullableClassTest extends TestCase
     public function testPropertyArrayNullableProp()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -148,7 +148,7 @@ class NullableClassTest extends TestCase
     public function testPropertyArrayAndItemsNullableProp()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -157,7 +157,7 @@ class NullableClassTest extends TestCase
     public function testPropertyArrayItemsNullable()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -166,7 +166,7 @@ class NullableClassTest extends TestCase
     public function testPropertyObjectNullableProp()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -175,7 +175,7 @@ class NullableClassTest extends TestCase
     public function testPropertyObjectAndItemsNullableProp()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -184,6 +184,6 @@ class NullableClassTest extends TestCase
     public function testPropertyObjectItemsNullable()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/psr-18/test/Model/NumberOnlyTest.php
+++ b/samples/client/petstore/php/psr-18/test/Model/NumberOnlyTest.php
@@ -76,7 +76,7 @@ class NumberOnlyTest extends TestCase
     public function testNumberOnly()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,6 +85,6 @@ class NumberOnlyTest extends TestCase
     public function testPropertyJustNumber()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/psr-18/test/Model/ObjectWithDeprecatedFieldsTest.php
+++ b/samples/client/petstore/php/psr-18/test/Model/ObjectWithDeprecatedFieldsTest.php
@@ -76,7 +76,7 @@ class ObjectWithDeprecatedFieldsTest extends TestCase
     public function testObjectWithDeprecatedFields()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class ObjectWithDeprecatedFieldsTest extends TestCase
     public function testPropertyUuid()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,7 +94,7 @@ class ObjectWithDeprecatedFieldsTest extends TestCase
     public function testPropertyId()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -103,7 +103,7 @@ class ObjectWithDeprecatedFieldsTest extends TestCase
     public function testPropertyDeprecatedRef()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -112,6 +112,6 @@ class ObjectWithDeprecatedFieldsTest extends TestCase
     public function testPropertyBars()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/psr-18/test/Model/OrderTest.php
+++ b/samples/client/petstore/php/psr-18/test/Model/OrderTest.php
@@ -76,7 +76,7 @@ class OrderTest extends TestCase
     public function testOrder()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class OrderTest extends TestCase
     public function testPropertyId()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,7 +94,7 @@ class OrderTest extends TestCase
     public function testPropertyPetId()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -103,7 +103,7 @@ class OrderTest extends TestCase
     public function testPropertyQuantity()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -112,7 +112,7 @@ class OrderTest extends TestCase
     public function testPropertyShipDate()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -121,7 +121,7 @@ class OrderTest extends TestCase
     public function testPropertyStatus()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -130,6 +130,6 @@ class OrderTest extends TestCase
     public function testPropertyComplete()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/psr-18/test/Model/OuterCompositeTest.php
+++ b/samples/client/petstore/php/psr-18/test/Model/OuterCompositeTest.php
@@ -76,7 +76,7 @@ class OuterCompositeTest extends TestCase
     public function testOuterComposite()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class OuterCompositeTest extends TestCase
     public function testPropertyMyNumber()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,7 +94,7 @@ class OuterCompositeTest extends TestCase
     public function testPropertyMyString()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -103,6 +103,6 @@ class OuterCompositeTest extends TestCase
     public function testPropertyMyBoolean()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/psr-18/test/Model/OuterEnumDefaultValueTest.php
+++ b/samples/client/petstore/php/psr-18/test/Model/OuterEnumDefaultValueTest.php
@@ -76,6 +76,6 @@ class OuterEnumDefaultValueTest extends TestCase
     public function testOuterEnumDefaultValue()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/psr-18/test/Model/OuterEnumIntegerDefaultValueTest.php
+++ b/samples/client/petstore/php/psr-18/test/Model/OuterEnumIntegerDefaultValueTest.php
@@ -76,6 +76,6 @@ class OuterEnumIntegerDefaultValueTest extends TestCase
     public function testOuterEnumIntegerDefaultValue()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/psr-18/test/Model/OuterEnumIntegerTest.php
+++ b/samples/client/petstore/php/psr-18/test/Model/OuterEnumIntegerTest.php
@@ -76,6 +76,6 @@ class OuterEnumIntegerTest extends TestCase
     public function testOuterEnumInteger()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/psr-18/test/Model/OuterEnumTest.php
+++ b/samples/client/petstore/php/psr-18/test/Model/OuterEnumTest.php
@@ -76,6 +76,6 @@ class OuterEnumTest extends TestCase
     public function testOuterEnum()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/psr-18/test/Model/OuterObjectWithEnumPropertyTest.php
+++ b/samples/client/petstore/php/psr-18/test/Model/OuterObjectWithEnumPropertyTest.php
@@ -76,7 +76,7 @@ class OuterObjectWithEnumPropertyTest extends TestCase
     public function testOuterObjectWithEnumProperty()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,6 +85,6 @@ class OuterObjectWithEnumPropertyTest extends TestCase
     public function testPropertyValue()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/psr-18/test/Model/PetTest.php
+++ b/samples/client/petstore/php/psr-18/test/Model/PetTest.php
@@ -76,7 +76,7 @@ class PetTest extends TestCase
     public function testPet()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class PetTest extends TestCase
     public function testPropertyId()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,7 +94,7 @@ class PetTest extends TestCase
     public function testPropertyCategory()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -103,7 +103,7 @@ class PetTest extends TestCase
     public function testPropertyName()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -112,7 +112,7 @@ class PetTest extends TestCase
     public function testPropertyPhotoUrls()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -121,7 +121,7 @@ class PetTest extends TestCase
     public function testPropertyTags()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -130,6 +130,6 @@ class PetTest extends TestCase
     public function testPropertyStatus()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/psr-18/test/Model/PropertyNameMappingTest.php
+++ b/samples/client/petstore/php/psr-18/test/Model/PropertyNameMappingTest.php
@@ -76,7 +76,7 @@ class PropertyNameMappingTest extends TestCase
     public function testPropertyNameMapping()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class PropertyNameMappingTest extends TestCase
     public function testPropertyHttpDebugOperation()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,7 +94,7 @@ class PropertyNameMappingTest extends TestCase
     public function testPropertyUnderscoreType()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -103,7 +103,7 @@ class PropertyNameMappingTest extends TestCase
     public function testPropertyType()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -112,6 +112,6 @@ class PropertyNameMappingTest extends TestCase
     public function testPropertyTypeWithUnderscore()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/psr-18/test/Model/ReadOnlyFirstTest.php
+++ b/samples/client/petstore/php/psr-18/test/Model/ReadOnlyFirstTest.php
@@ -76,7 +76,7 @@ class ReadOnlyFirstTest extends TestCase
     public function testReadOnlyFirst()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class ReadOnlyFirstTest extends TestCase
     public function testPropertyBar()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,6 +94,6 @@ class ReadOnlyFirstTest extends TestCase
     public function testPropertyBaz()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/psr-18/test/Model/SingleRefTypeTest.php
+++ b/samples/client/petstore/php/psr-18/test/Model/SingleRefTypeTest.php
@@ -76,6 +76,6 @@ class SingleRefTypeTest extends TestCase
     public function testSingleRefType()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/psr-18/test/Model/SpecialModelNameTest.php
+++ b/samples/client/petstore/php/psr-18/test/Model/SpecialModelNameTest.php
@@ -76,7 +76,7 @@ class SpecialModelNameTest extends TestCase
     public function testSpecialModelName()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,6 +85,6 @@ class SpecialModelNameTest extends TestCase
     public function testPropertySpecialPropertyName()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/psr-18/test/Model/TagTest.php
+++ b/samples/client/petstore/php/psr-18/test/Model/TagTest.php
@@ -76,7 +76,7 @@ class TagTest extends TestCase
     public function testTag()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class TagTest extends TestCase
     public function testPropertyId()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,6 +94,6 @@ class TagTest extends TestCase
     public function testPropertyName()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/psr-18/test/Model/TestInlineFreeformAdditionalPropertiesRequestTest.php
+++ b/samples/client/petstore/php/psr-18/test/Model/TestInlineFreeformAdditionalPropertiesRequestTest.php
@@ -76,7 +76,7 @@ class TestInlineFreeformAdditionalPropertiesRequestTest extends TestCase
     public function testTestInlineFreeformAdditionalPropertiesRequest()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,6 +85,6 @@ class TestInlineFreeformAdditionalPropertiesRequestTest extends TestCase
     public function testPropertySomeProperty()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/client/petstore/php/psr-18/test/Model/UserTest.php
+++ b/samples/client/petstore/php/psr-18/test/Model/UserTest.php
@@ -76,7 +76,7 @@ class UserTest extends TestCase
     public function testUser()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -85,7 +85,7 @@ class UserTest extends TestCase
     public function testPropertyId()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -94,7 +94,7 @@ class UserTest extends TestCase
     public function testPropertyUsername()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -103,7 +103,7 @@ class UserTest extends TestCase
     public function testPropertyFirstName()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -112,7 +112,7 @@ class UserTest extends TestCase
     public function testPropertyLastName()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -121,7 +121,7 @@ class UserTest extends TestCase
     public function testPropertyEmail()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -130,7 +130,7 @@ class UserTest extends TestCase
     public function testPropertyPassword()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -139,7 +139,7 @@ class UserTest extends TestCase
     public function testPropertyPhone()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 
     /**
@@ -148,6 +148,6 @@ class UserTest extends TestCase
     public function testPropertyUserStatus()
     {
         // TODO: implement
-        $this->markTestIncomplete('Not implemented');
+        self::markTestIncomplete('Not implemented');
     }
 }

--- a/samples/server/petstore/php-slim4/tests/Api/PetApiTest.php
+++ b/samples/server/petstore/php-slim4/tests/Api/PetApiTest.php
@@ -74,7 +74,7 @@ class PetApiTest extends TestCase
      */
     public function testAddPet()
     {
-        $this->markTestIncomplete(
+        self::markTestIncomplete(
             'Test of "addPet" method has not been implemented yet.'
         );
     }
@@ -88,7 +88,7 @@ class PetApiTest extends TestCase
      */
     public function testDeletePet()
     {
-        $this->markTestIncomplete(
+        self::markTestIncomplete(
             'Test of "deletePet" method has not been implemented yet.'
         );
     }
@@ -102,7 +102,7 @@ class PetApiTest extends TestCase
      */
     public function testFindPetsByStatus()
     {
-        $this->markTestIncomplete(
+        self::markTestIncomplete(
             'Test of "findPetsByStatus" method has not been implemented yet.'
         );
     }
@@ -116,7 +116,7 @@ class PetApiTest extends TestCase
      */
     public function testFindPetsByTags()
     {
-        $this->markTestIncomplete(
+        self::markTestIncomplete(
             'Test of "findPetsByTags" method has not been implemented yet.'
         );
     }
@@ -130,7 +130,7 @@ class PetApiTest extends TestCase
      */
     public function testGetPetById()
     {
-        $this->markTestIncomplete(
+        self::markTestIncomplete(
             'Test of "getPetById" method has not been implemented yet.'
         );
     }
@@ -144,7 +144,7 @@ class PetApiTest extends TestCase
      */
     public function testUpdatePet()
     {
-        $this->markTestIncomplete(
+        self::markTestIncomplete(
             'Test of "updatePet" method has not been implemented yet.'
         );
     }
@@ -158,7 +158,7 @@ class PetApiTest extends TestCase
      */
     public function testUpdatePetWithForm()
     {
-        $this->markTestIncomplete(
+        self::markTestIncomplete(
             'Test of "updatePetWithForm" method has not been implemented yet.'
         );
     }
@@ -172,7 +172,7 @@ class PetApiTest extends TestCase
      */
     public function testUploadFile()
     {
-        $this->markTestIncomplete(
+        self::markTestIncomplete(
             'Test of "uploadFile" method has not been implemented yet.'
         );
     }

--- a/samples/server/petstore/php-slim4/tests/Api/StoreApiTest.php
+++ b/samples/server/petstore/php-slim4/tests/Api/StoreApiTest.php
@@ -74,7 +74,7 @@ class StoreApiTest extends TestCase
      */
     public function testDeleteOrder()
     {
-        $this->markTestIncomplete(
+        self::markTestIncomplete(
             'Test of "deleteOrder" method has not been implemented yet.'
         );
     }
@@ -88,7 +88,7 @@ class StoreApiTest extends TestCase
      */
     public function testGetInventory()
     {
-        $this->markTestIncomplete(
+        self::markTestIncomplete(
             'Test of "getInventory" method has not been implemented yet.'
         );
     }
@@ -102,7 +102,7 @@ class StoreApiTest extends TestCase
      */
     public function testGetOrderById()
     {
-        $this->markTestIncomplete(
+        self::markTestIncomplete(
             'Test of "getOrderById" method has not been implemented yet.'
         );
     }
@@ -116,7 +116,7 @@ class StoreApiTest extends TestCase
      */
     public function testPlaceOrder()
     {
-        $this->markTestIncomplete(
+        self::markTestIncomplete(
             'Test of "placeOrder" method has not been implemented yet.'
         );
     }

--- a/samples/server/petstore/php-slim4/tests/Api/UserApiTest.php
+++ b/samples/server/petstore/php-slim4/tests/Api/UserApiTest.php
@@ -74,7 +74,7 @@ class UserApiTest extends TestCase
      */
     public function testCreateUser()
     {
-        $this->markTestIncomplete(
+        self::markTestIncomplete(
             'Test of "createUser" method has not been implemented yet.'
         );
     }
@@ -88,7 +88,7 @@ class UserApiTest extends TestCase
      */
     public function testCreateUsersWithArrayInput()
     {
-        $this->markTestIncomplete(
+        self::markTestIncomplete(
             'Test of "createUsersWithArrayInput" method has not been implemented yet.'
         );
     }
@@ -102,7 +102,7 @@ class UserApiTest extends TestCase
      */
     public function testCreateUsersWithListInput()
     {
-        $this->markTestIncomplete(
+        self::markTestIncomplete(
             'Test of "createUsersWithListInput" method has not been implemented yet.'
         );
     }
@@ -116,7 +116,7 @@ class UserApiTest extends TestCase
      */
     public function testDeleteUser()
     {
-        $this->markTestIncomplete(
+        self::markTestIncomplete(
             'Test of "deleteUser" method has not been implemented yet.'
         );
     }
@@ -130,7 +130,7 @@ class UserApiTest extends TestCase
      */
     public function testGetUserByName()
     {
-        $this->markTestIncomplete(
+        self::markTestIncomplete(
             'Test of "getUserByName" method has not been implemented yet.'
         );
     }
@@ -144,7 +144,7 @@ class UserApiTest extends TestCase
      */
     public function testLoginUser()
     {
-        $this->markTestIncomplete(
+        self::markTestIncomplete(
             'Test of "loginUser" method has not been implemented yet.'
         );
     }
@@ -158,7 +158,7 @@ class UserApiTest extends TestCase
      */
     public function testLogoutUser()
     {
-        $this->markTestIncomplete(
+        self::markTestIncomplete(
             'Test of "logoutUser" method has not been implemented yet.'
         );
     }
@@ -172,7 +172,7 @@ class UserApiTest extends TestCase
      */
     public function testUpdateUser()
     {
-        $this->markTestIncomplete(
+        self::markTestIncomplete(
             'Test of "updateUser" method has not been implemented yet.'
         );
     }

--- a/samples/server/petstore/php-slim4/tests/Model/ApiResponseTest.php
+++ b/samples/server/petstore/php-slim4/tests/Model/ApiResponseTest.php
@@ -77,7 +77,7 @@ class ApiResponseTest extends TestCase
             class_exists($namespacedClassname),
             sprintf('Assertion failed that "%s" class exists', $namespacedClassname)
         );
-        $this->markTestIncomplete(
+        self::markTestIncomplete(
             'Test of "ApiResponse" model has not been implemented yet.'
         );
     }
@@ -87,7 +87,7 @@ class ApiResponseTest extends TestCase
      */
     public function testPropertyCode()
     {
-        $this->markTestIncomplete(
+        self::markTestIncomplete(
             'Test of "code" property in "ApiResponse" model has not been implemented yet.'
         );
     }
@@ -97,7 +97,7 @@ class ApiResponseTest extends TestCase
      */
     public function testPropertyType()
     {
-        $this->markTestIncomplete(
+        self::markTestIncomplete(
             'Test of "type" property in "ApiResponse" model has not been implemented yet.'
         );
     }
@@ -107,7 +107,7 @@ class ApiResponseTest extends TestCase
      */
     public function testPropertyMessage()
     {
-        $this->markTestIncomplete(
+        self::markTestIncomplete(
             'Test of "message" property in "ApiResponse" model has not been implemented yet.'
         );
     }

--- a/samples/server/petstore/php-slim4/tests/Model/CategoryTest.php
+++ b/samples/server/petstore/php-slim4/tests/Model/CategoryTest.php
@@ -77,7 +77,7 @@ class CategoryTest extends TestCase
             class_exists($namespacedClassname),
             sprintf('Assertion failed that "%s" class exists', $namespacedClassname)
         );
-        $this->markTestIncomplete(
+        self::markTestIncomplete(
             'Test of "Category" model has not been implemented yet.'
         );
     }
@@ -87,7 +87,7 @@ class CategoryTest extends TestCase
      */
     public function testPropertyId()
     {
-        $this->markTestIncomplete(
+        self::markTestIncomplete(
             'Test of "id" property in "Category" model has not been implemented yet.'
         );
     }
@@ -97,7 +97,7 @@ class CategoryTest extends TestCase
      */
     public function testPropertyName()
     {
-        $this->markTestIncomplete(
+        self::markTestIncomplete(
             'Test of "name" property in "Category" model has not been implemented yet.'
         );
     }

--- a/samples/server/petstore/php-slim4/tests/Model/OrderTest.php
+++ b/samples/server/petstore/php-slim4/tests/Model/OrderTest.php
@@ -77,7 +77,7 @@ class OrderTest extends TestCase
             class_exists($namespacedClassname),
             sprintf('Assertion failed that "%s" class exists', $namespacedClassname)
         );
-        $this->markTestIncomplete(
+        self::markTestIncomplete(
             'Test of "Order" model has not been implemented yet.'
         );
     }
@@ -87,7 +87,7 @@ class OrderTest extends TestCase
      */
     public function testPropertyId()
     {
-        $this->markTestIncomplete(
+        self::markTestIncomplete(
             'Test of "id" property in "Order" model has not been implemented yet.'
         );
     }
@@ -97,7 +97,7 @@ class OrderTest extends TestCase
      */
     public function testPropertyPetId()
     {
-        $this->markTestIncomplete(
+        self::markTestIncomplete(
             'Test of "petId" property in "Order" model has not been implemented yet.'
         );
     }
@@ -107,7 +107,7 @@ class OrderTest extends TestCase
      */
     public function testPropertyQuantity()
     {
-        $this->markTestIncomplete(
+        self::markTestIncomplete(
             'Test of "quantity" property in "Order" model has not been implemented yet.'
         );
     }
@@ -117,7 +117,7 @@ class OrderTest extends TestCase
      */
     public function testPropertyShipDate()
     {
-        $this->markTestIncomplete(
+        self::markTestIncomplete(
             'Test of "shipDate" property in "Order" model has not been implemented yet.'
         );
     }
@@ -127,7 +127,7 @@ class OrderTest extends TestCase
      */
     public function testPropertyStatus()
     {
-        $this->markTestIncomplete(
+        self::markTestIncomplete(
             'Test of "status" property in "Order" model has not been implemented yet.'
         );
     }
@@ -137,7 +137,7 @@ class OrderTest extends TestCase
      */
     public function testPropertyComplete()
     {
-        $this->markTestIncomplete(
+        self::markTestIncomplete(
             'Test of "complete" property in "Order" model has not been implemented yet.'
         );
     }

--- a/samples/server/petstore/php-slim4/tests/Model/PetTest.php
+++ b/samples/server/petstore/php-slim4/tests/Model/PetTest.php
@@ -77,7 +77,7 @@ class PetTest extends TestCase
             class_exists($namespacedClassname),
             sprintf('Assertion failed that "%s" class exists', $namespacedClassname)
         );
-        $this->markTestIncomplete(
+        self::markTestIncomplete(
             'Test of "Pet" model has not been implemented yet.'
         );
     }
@@ -87,7 +87,7 @@ class PetTest extends TestCase
      */
     public function testPropertyId()
     {
-        $this->markTestIncomplete(
+        self::markTestIncomplete(
             'Test of "id" property in "Pet" model has not been implemented yet.'
         );
     }
@@ -97,7 +97,7 @@ class PetTest extends TestCase
      */
     public function testPropertyCategory()
     {
-        $this->markTestIncomplete(
+        self::markTestIncomplete(
             'Test of "category" property in "Pet" model has not been implemented yet.'
         );
     }
@@ -107,7 +107,7 @@ class PetTest extends TestCase
      */
     public function testPropertyName()
     {
-        $this->markTestIncomplete(
+        self::markTestIncomplete(
             'Test of "name" property in "Pet" model has not been implemented yet.'
         );
     }
@@ -117,7 +117,7 @@ class PetTest extends TestCase
      */
     public function testPropertyPhotoUrls()
     {
-        $this->markTestIncomplete(
+        self::markTestIncomplete(
             'Test of "photoUrls" property in "Pet" model has not been implemented yet.'
         );
     }
@@ -127,7 +127,7 @@ class PetTest extends TestCase
      */
     public function testPropertyTags()
     {
-        $this->markTestIncomplete(
+        self::markTestIncomplete(
             'Test of "tags" property in "Pet" model has not been implemented yet.'
         );
     }
@@ -137,7 +137,7 @@ class PetTest extends TestCase
      */
     public function testPropertyStatus()
     {
-        $this->markTestIncomplete(
+        self::markTestIncomplete(
             'Test of "status" property in "Pet" model has not been implemented yet.'
         );
     }

--- a/samples/server/petstore/php-slim4/tests/Model/TagTest.php
+++ b/samples/server/petstore/php-slim4/tests/Model/TagTest.php
@@ -77,7 +77,7 @@ class TagTest extends TestCase
             class_exists($namespacedClassname),
             sprintf('Assertion failed that "%s" class exists', $namespacedClassname)
         );
-        $this->markTestIncomplete(
+        self::markTestIncomplete(
             'Test of "Tag" model has not been implemented yet.'
         );
     }
@@ -87,7 +87,7 @@ class TagTest extends TestCase
      */
     public function testPropertyId()
     {
-        $this->markTestIncomplete(
+        self::markTestIncomplete(
             'Test of "id" property in "Tag" model has not been implemented yet.'
         );
     }
@@ -97,7 +97,7 @@ class TagTest extends TestCase
      */
     public function testPropertyName()
     {
-        $this->markTestIncomplete(
+        self::markTestIncomplete(
             'Test of "name" property in "Tag" model has not been implemented yet.'
         );
     }

--- a/samples/server/petstore/php-slim4/tests/Model/UserTest.php
+++ b/samples/server/petstore/php-slim4/tests/Model/UserTest.php
@@ -77,7 +77,7 @@ class UserTest extends TestCase
             class_exists($namespacedClassname),
             sprintf('Assertion failed that "%s" class exists', $namespacedClassname)
         );
-        $this->markTestIncomplete(
+        self::markTestIncomplete(
             'Test of "User" model has not been implemented yet.'
         );
     }
@@ -87,7 +87,7 @@ class UserTest extends TestCase
      */
     public function testPropertyId()
     {
-        $this->markTestIncomplete(
+        self::markTestIncomplete(
             'Test of "id" property in "User" model has not been implemented yet.'
         );
     }
@@ -97,7 +97,7 @@ class UserTest extends TestCase
      */
     public function testPropertyUsername()
     {
-        $this->markTestIncomplete(
+        self::markTestIncomplete(
             'Test of "username" property in "User" model has not been implemented yet.'
         );
     }
@@ -107,7 +107,7 @@ class UserTest extends TestCase
      */
     public function testPropertyFirstName()
     {
-        $this->markTestIncomplete(
+        self::markTestIncomplete(
             'Test of "firstName" property in "User" model has not been implemented yet.'
         );
     }
@@ -117,7 +117,7 @@ class UserTest extends TestCase
      */
     public function testPropertyLastName()
     {
-        $this->markTestIncomplete(
+        self::markTestIncomplete(
             'Test of "lastName" property in "User" model has not been implemented yet.'
         );
     }
@@ -127,7 +127,7 @@ class UserTest extends TestCase
      */
     public function testPropertyEmail()
     {
-        $this->markTestIncomplete(
+        self::markTestIncomplete(
             'Test of "email" property in "User" model has not been implemented yet.'
         );
     }
@@ -137,7 +137,7 @@ class UserTest extends TestCase
      */
     public function testPropertyPassword()
     {
-        $this->markTestIncomplete(
+        self::markTestIncomplete(
             'Test of "password" property in "User" model has not been implemented yet.'
         );
     }
@@ -147,7 +147,7 @@ class UserTest extends TestCase
      */
     public function testPropertyPhone()
     {
-        $this->markTestIncomplete(
+        self::markTestIncomplete(
             'Test of "phone" property in "User" model has not been implemented yet.'
         );
     }
@@ -157,7 +157,7 @@ class UserTest extends TestCase
      */
     public function testPropertyUserStatus()
     {
-        $this->markTestIncomplete(
+        self::markTestIncomplete(
             'Test of "userStatus" property in "User" model has not been implemented yet.'
         );
     }


### PR DESCRIPTION
It's reported by phpstan as `Dynamic call to static method PHPUnit\Framework\Assert::markTestIncomplete().`.

The method is static, therefore it should not be called from instance context.

<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->

<!-- Please check the completed items below -->
### PR checklist
 
- [ ] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [ ] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [ ] Run the following to [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) and update samples:
  ```
  ./mvnw clean package 
  ./bin/generate-samples.sh ./bin/configs/*.yaml
  ./bin/utils/export_docs_generators.sh
  ``` 
  (For Windows users, please run the script in [Git BASH](https://gitforwindows.org/))
  Commit all changed files. 
  This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. 
  These must match the expectations made by your contribution. 
  You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. 
  IMPORTANT: Do **NOT** purge/delete any folders/files (e.g. tests) when regenerating the samples as manually written tests may be removed.
- [ ] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master` (upcoming 7.1.0 minor release - breaking changes with fallbacks), `8.0.x` (breaking changes without fallbacks)
- [ ] If your PR is targeting a particular programming language, @mention the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) members, so they are more likely to review the pull request.
